### PR TITLE
fix: cancel after releaseLock throws INVALID_STATE error

### DIFF
--- a/src/lib/blockstore.js
+++ b/src/lib/blockstore.js
@@ -113,14 +113,10 @@ export class BatchingR2Blockstore extends R2Blockstore {
 
         const reader = res.body.getReader()
         const bytesReader = asyncIterableReader((async function * () {
-          try {
-            while (true) {
-              const { done, value } = await reader.read()
-              if (done) return
-              yield value
-            }
-          } finally {
-            reader.releaseLock()
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) return
+            yield value
           }
         })())
 


### PR DESCRIPTION
While testing locally I was unable to fetch a file because the stream was being cancelled after `releaseLock` was called.

```
TypeError [ERR_INVALID_STATE]: Invalid state: The reader is not attached to a stream
    at new NodeError (node:internal/errors:393:5)
    at ReadableStreamDefaultReader.cancel (node:internal/webstreams/readablestream:837:28)
    at #processBatch (/Users/alan/Code/web3-storage/freeway/dist/worker.mjs:24428:16) {
  code: 'ERR_INVALID_STATE'
}
```

We don't need to `releaseLock` because we're the only reader so I've removed it and I no longer get this error.