### PR TITLE
fix: temporarily limit the size of the response until memory leak is resolved

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ import {
   withUnsupportedFeaturesHandler,
   withMemoryBudget,
   withResponseMemoryRelease,
-  withVersionHeader
+  withVersionHeader,
+  withMaxContentLength
 } from './middleware.js'
 
 /**
@@ -29,6 +30,11 @@ import {
  * @typedef {import('./bindings').CarCidsContext} CarCidsContext
  * @typedef {import('@web3-storage/gateway-lib').DagulaContext} DagulaContext
  */
+
+/**
+ * Temporary limit to the size of the response until memory leak is resolved.
+ */
+const MAX_CONTENT_LENGTH = 1024 * 1024 * 128
 
 export default {
   /** @type {import('@web3-storage/gateway-lib').Handler<import('@web3-storage/gateway-lib').Context, import('./bindings').Environment>} */
@@ -47,7 +53,8 @@ export default {
       withMemoryBudget,
       withDagula,
       withFixedLengthStream,
-      withResponseMemoryRelease
+      withResponseMemoryRelease,
+      withMaxContentLength.bind(null, MAX_CONTENT_LENGTH)
     )
     return middleware(handler)(request, env, ctx)
   }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -169,13 +169,10 @@ export function withMaxContentLength (maxLength, handler) {
    */
   return async (request, env, ctx) => {
     const response = await handler(request, env, ctx)
-    if (!response.headers.has('Content-Length')) return response
-
-    const contentLength = parseInt(response.headers.get('Content-Length') || '0')
+    const contentLength = parseInt(response.headers.get('Content-Length') ?? '0')
     if (contentLength > maxLength) {
       throw new HttpError('Content too big', { status: 403 })
     }
-
     return response
   }
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -155,3 +155,27 @@ export function withVersionHeader (handler) {
     return response
   }
 }
+
+/**
+ * This middleware throws if the Content-Length header is set and it is greater
+ * than the provided max value.
+ *
+ * @param {number} maxLength
+ * @param {import('@web3-storage/gateway-lib').Handler<import('@web3-storage/gateway-lib').Context>} handler
+ */
+export function withMaxContentLength (maxLength, handler) {
+  /**
+   * @type {import('@web3-storage/gateway-lib').Handler<import('@web3-storage/gateway-lib').Context>}
+   */
+  return async (request, env, ctx) => {
+    const response = await handler(request, env, ctx)
+    if (!response.headers.has('Content-Length')) return response
+
+    const contentLength = parseInt(response.headers.get('Content-Length') || '0')
+    if (contentLength > maxLength) {
+      throw new HttpError('Content too big', { status: 403 })
+    }
+
+    return response
+  }
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -59,7 +59,7 @@ describe('freeway', () => {
   })
 
   it('should get a big file', async () => {
-    const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
+    const input = [{ path: 'sargo.tar.xz', content: randomBytes(1024 * 1024 * 128) }]
     const { dataCid } = await builder.add(input)
 
     const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
@@ -67,5 +67,12 @@ describe('freeway', () => {
 
     const output = new Uint8Array(await res.arrayBuffer())
     assert(equals(input[0].content, output))
+  })
+
+  it('should fail to get a file bigger than 128MB', async () => {
+    const input = [{ path: 'sargo.tar.xz', content: randomBytes(1024 * 1024 * 128 + 1) }]
+    const { dataCid } = await builder.add(input)
+    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+    assert.strictEqual(res.status, 403)
   })
 })


### PR DESCRIPTION
This should allow us to get freeway back into production while we fix the memory leak.