### PR TITLE
fix: allow hash character in directory listings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,30 +9,29 @@
       "version": "1.6.0",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@ipld/car": "^4.1.5",
-        "@ipld/dag-cbor": "^7.0.3",
-        "@ipld/dag-json": "^8.0.11",
-        "@ipld/dag-pb": "^2.1.18",
-        "@web3-storage/fast-unixfs-exporter": "^0.2.0",
-        "@web3-storage/gateway-lib": "^2.0.2",
-        "cardex": "^1.0.0",
+        "@ipld/car": "^5.1.0",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.1",
+        "@ipld/dag-pb": "^4.0.2",
+        "@web3-storage/gateway-lib": "^2.0.3",
+        "cardex": "^1.0.1",
         "chardet": "^1.5.0",
-        "dagula": "^4.1.1",
+        "dagula": "^5.0.0",
         "magic-bytes.js": "^1.0.12",
         "mrmime": "^1.0.1",
-        "multiformats": "^9.9.0",
+        "multiformats": "^11.0.2",
         "p-defer": "^4.0.0",
         "streaming-iterables": "^7.1.0"
       },
       "devDependencies": {
-        "ava": "^4.3.3",
+        "ava": "^5.2.0",
         "carbites": "^1.0.6",
-        "esbuild": "^0.15.10",
+        "esbuild": "^0.17.11",
         "files-from-path": "^0.2.6",
-        "ipfs-car": "^0.8.1",
+        "ipfs-car": "^0.9.2",
         "miniflare": "^2.9.0",
         "standard": "^17.0.0",
-        "uint8arrays": "^3.1.1"
+        "uint8arrays": "^4.0.3"
       }
     },
     "node_modules/@achingbrain/ip-address": {
@@ -163,46 +162,47 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
+      "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
+    },
     "node_modules/@chainsafe/libp2p-noise": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-7.0.3.tgz",
-      "integrity": "sha512-kr68a6zEC2y1sp9O1i8MlPu7LgC4U1sLciG/SF9Hvo0kOdDa5a13l3Il9R3rTIqaL9DoVfmQhfpOR/cxY2PWUw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.1.tgz",
+      "integrity": "sha512-pByMPsbuuiAherDV7DRB/sBmxWJcLt2tkuST4vFpv6FZb3/AxKp+ck2f4pHFNaUCaFbGLQa2wN903i8tq8Qr7Q==",
       "dependencies": {
-        "@libp2p/crypto": "^1.0.0",
-        "@libp2p/interface-connection-encrypter": "^1.0.2",
-        "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interface-peer-id": "^1.0.2",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/peer-collections": "^2.0.0",
-        "@libp2p/peer-id": "^1.1.8",
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-connection-encrypter": "^3.0.5",
+        "@libp2p/interface-keys": "^1.0.6",
+        "@libp2p/interface-metrics": "^4.0.4",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
         "@stablelib/chacha20poly1305": "^1.0.1",
         "@stablelib/hkdf": "^1.0.1",
         "@stablelib/sha256": "^1.0.1",
-        "@stablelib/x25519": "^1.0.1",
+        "@stablelib/x25519": "^1.0.3",
         "it-length-prefixed": "^8.0.2",
         "it-pair": "^2.0.2",
-        "it-pb-stream": "^2.0.1",
+        "it-pb-stream": "^2.0.2",
         "it-pipe": "^2.0.3",
         "it-stream-types": "^1.0.4",
-        "protons-runtime": "^2.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "protons-runtime": "^4.0.1",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@chainsafe/libp2p-noise/node_modules/it-length-prefixed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-      "integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
+    "node_modules/@chainsafe/libp2p-noise/node_modules/it-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+      "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
       "dependencies": {
-        "err-code": "^3.0.1",
-        "it-stream-types": "^1.0.4",
-        "uint8-varint": "^1.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "it-pushable": "^3.1.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -210,11 +210,11 @@
       }
     },
     "node_modules/@chainsafe/libp2p-noise/node_modules/it-pipe": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-      "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
       "dependencies": {
-        "it-merge": "^1.0.4",
+        "it-merge": "^2.0.0",
         "it-pushable": "^3.1.0",
         "it-stream-types": "^1.0.3"
       },
@@ -223,26 +223,10 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@chainsafe/libp2p-noise/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.10.tgz",
-      "integrity": "sha512-FNONeQPy/ox+5NBkcSbYJxoXj9GWu8gVGJTVmUyoOCKQFDTrHVKgNSzChdNt0I8Aj/iKcsDf2r9BFwv+FSNUXg==",
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.11.tgz",
+      "integrity": "sha512-CdyX6sRVh1NzFCsf5vw3kULwlAhfy9wVt8SZlrhQ7eL2qBjGbFhRBWkkAzuZm9IIEOCKJw4DXA6R85g+qc8RDw==",
       "cpu": [
         "arm"
       ],
@@ -255,10 +239,154 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.11.tgz",
+      "integrity": "sha512-QnK4d/zhVTuV4/pRM4HUjcsbl43POALU2zvBynmrrqZt9LPcLA3x1fTZPBg2RRguBQnJcnU059yKr+bydkntjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.11.tgz",
+      "integrity": "sha512-3PL3HKtsDIXGQcSCKtWD/dy+mgc4p2Tvo2qKgKHj9Yf+eniwFnuoQ0OUhlSfAEpKAFzF9N21Nwgnap6zy3L3MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.11.tgz",
+      "integrity": "sha512-pJ950bNKgzhkGNO3Z9TeHzIFtEyC2GDQL3wxkMApDEghYx5Qers84UTNc1bAxWbRkuJOgmOha5V0WUeh8G+YGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.11.tgz",
+      "integrity": "sha512-iB0dQkIHXyczK3BZtzw1tqegf0F0Ab5texX2TvMQjiJIWXAfM4FQl7D909YfXWnB92OQz4ivBYQ2RlxBJrMJOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.11.tgz",
+      "integrity": "sha512-7EFzUADmI1jCHeDRGKgbnF5sDIceZsQGapoO6dmw7r/ZBEKX7CCDnIz8m9yEclzr7mFsd+DyasHzpjfJnmBB1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.11.tgz",
+      "integrity": "sha512-iPgenptC8i8pdvkHQvXJFzc1eVMR7W2lBPrTE6GbhR54sLcF42mk3zBOjKPOodezzuAz/KSu8CPyFSjcBMkE9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.11.tgz",
+      "integrity": "sha512-M9iK/d4lgZH0U5M1R2p2gqhPV/7JPJcRz+8O8GBKVgqndTzydQ7B2XGDbxtbvFkvIs53uXTobOhv+RyaqhUiMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.11.tgz",
+      "integrity": "sha512-Qxth3gsWWGKz2/qG2d5DsW/57SeA2AmpSMhdg9TSB5Svn2KDob3qxfQSkdnWjSd42kqoxIPy3EJFs+6w1+6Qjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.11.tgz",
+      "integrity": "sha512-dB1nGaVWtUlb/rRDHmuDQhfqazWE0LMro/AIbT2lWM3CDMHJNpLckH+gCddQyhhcLac2OYw69ikUMO34JLt3wA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.10.tgz",
-      "integrity": "sha512-w0Ou3Z83LOYEkwaui2M8VwIp+nLi/NA60lBLMvaJ+vXVMcsARYdEzLNE7RSm4+lSg4zq4d7fAVuzk7PNQ5JFgg==",
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.11.tgz",
+      "integrity": "sha512-aCWlq70Q7Nc9WDnormntGS1ar6ZFvUpqr8gXtO+HRejRYPweAFQN615PcgaSJkZjhHp61+MNLhzyVALSF2/Q0g==",
       "cpu": [
         "loong64"
       ],
@@ -266,6 +394,182 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.11.tgz",
+      "integrity": "sha512-cGeGNdQxqY8qJwlYH1BP6rjIIiEcrM05H7k3tR7WxOLmD1ZxRMd6/QIOWMb8mD2s2YJFNRuNQ+wjMhgEL2oCEw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.11.tgz",
+      "integrity": "sha512-BdlziJQPW/bNe0E8eYsHB40mYOluS+jULPCjlWiHzDgr+ZBRXPtgMV1nkLEGdpjrwgmtkZHEGEPaKdS/8faLDA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.11.tgz",
+      "integrity": "sha512-MDLwQbtF+83oJCI1Cixn68Et/ME6gelmhssPebC40RdJaect+IM+l7o/CuG0ZlDs6tZTEIoxUe53H3GmMn8oMA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.11.tgz",
+      "integrity": "sha512-4N5EMESvws0Ozr2J94VoUD8HIRi7X0uvUv4c0wpTHZyZY9qpaaN7THjosdiW56irQ4qnJ6Lsc+i+5zGWnyqWqQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.11.tgz",
+      "integrity": "sha512-rM/v8UlluxpytFSmVdbCe1yyKQd/e+FmIJE2oPJvbBo+D0XVWi1y/NQ4iTNx+436WmDHQBjVLrbnAQLQ6U7wlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.11.tgz",
+      "integrity": "sha512-4WaAhuz5f91h3/g43VBGdto1Q+X7VEZfpcWGtOFXnggEuLvjV+cP6DyLRU15IjiU9fKLLk41OoJfBFN5DhPvag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.11.tgz",
+      "integrity": "sha512-UBj135Nx4FpnvtE+C8TWGp98oUgBcmNmdYgl5ToKc0mBHxVVqVE7FUS5/ELMImOp205qDAittL6Ezhasc2Ev/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.11.tgz",
+      "integrity": "sha512-1/gxTifDC9aXbV2xOfCbOceh5AlIidUrPsMpivgzo8P8zUtczlq1ncFpeN1ZyQJ9lVs2hILy1PG5KPp+w8QPPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.11.tgz",
+      "integrity": "sha512-vtSfyx5yRdpiOW9yp6Ax0zyNOv9HjOAw8WaZg3dF5djEHKKm3UnoohftVvIJtRh0Ec7Hso0RIdTqZvPXJ7FdvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.11.tgz",
+      "integrity": "sha512-GFPSLEGQr4wHFTiIUJQrnJKZhZjjq4Sphf+mM76nQR6WkQn73vm7IsacmBRPkALfpOCHsopSvLgqdd4iUW2mYw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.11.tgz",
+      "integrity": "sha512-N9vXqLP3eRL8BqSy8yn4Y98cZI2pZ8fyuHx6lKjiG2WABpT2l01TXdzq5Ma2ZUBzfB7tx5dXVhge8X9u0S70ZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -349,88 +653,52 @@
       "dev": true
     },
     "node_modules/@ipld/car": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-4.1.5.tgz",
-      "integrity": "sha512-PFj4XsKOsxu5h12JUoBJ+mrAVqeA8YYq2bZbcE2sAIopJTwJIB5sBVTmc8ylkUsFXEysZQ4xQD+rZb3Ct0lbjQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.0.tgz",
+      "integrity": "sha512-k9pO0YqJvmFGY5pJDhF2Ocz+mRp3C3r4ikr1NrUXkzN/z4JzhE7XbQzUCcm7daq8k4tRqap0fWPjxZwjS9PUcQ==",
       "dependencies": {
-        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-cbor": "^9.0.0",
         "cborg": "^1.9.0",
-        "multiformats": "^9.5.4",
+        "multiformats": "^11.0.0",
         "varint": "^6.0.0"
-      }
-    },
-    "node_modules/@ipld/dag-cbor": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
-      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
-      "dependencies": {
-        "cborg": "^1.6.0",
-        "multiformats": "^9.5.4"
-      }
-    },
-    "node_modules/@ipld/dag-json": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
-      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
-      "dependencies": {
-        "cborg": "^1.5.4",
-        "multiformats": "^9.5.4"
-      }
-    },
-    "node_modules/@ipld/dag-pb": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
-      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
-      "dependencies": {
-        "multiformats": "^9.5.4"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@libp2p/connection": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/connection/-/connection-2.0.4.tgz",
-      "integrity": "sha512-YGMa0ZTbKdyu4b58mLdVT3XKgfBGp/R5h2FTT/8sB3fHTkJ6Crl3Ad5a+cVuqsWfJhrHDncU3SJaqFH4fxhLmg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/connection/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
+    "node_modules/@ipld/dag-cbor": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
+      "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
       "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-json": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
+      "integrity": "sha512-XE1Eqw3eNVrSfOhtqCM/gwCxEgYFBzkDlkwhEeMmMvhd0rLBfSyVzXbahZSlv97tiTPEIx5rt41gcFAda3W8zg==",
+      "dependencies": {
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-pb": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
+      "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -438,18 +706,19 @@
       }
     },
     "node_modules/@libp2p/crypto": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.4.tgz",
-      "integrity": "sha512-3hHZvqi+vI8YoTHE+0u8nA5SYGPLZRLMvbgXQoAn0IyPjez66Taaxym/3p3Duf9QkFlvJu95nzpNzv0OdHs9Yw==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.14.tgz",
+      "integrity": "sha512-kS9bsRPS6qrbGiMfICjVUTjva7Bq0kCE0DTVGgFixH8e2RtF/7K8bWzO52aTQVPUF7vpId7cmmYAaHde1ZYh0A==",
       "dependencies": {
         "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interfaces": "^3.2.0",
         "@noble/ed25519": "^1.6.0",
         "@noble/secp256k1": "^1.5.4",
-        "err-code": "^3.0.1",
-        "multiformats": "^9.4.5",
+        "multiformats": "^11.0.0",
         "node-forge": "^1.1.0",
-        "protons-runtime": "^3.1.0",
-        "uint8arrays": "^3.0.0"
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -457,12 +726,12 @@
       }
     },
     "node_modules/@libp2p/crypto/node_modules/protons-runtime": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-3.1.0.tgz",
-      "integrity": "sha512-S1iSPQC0McdHKJRi0XcATBkWgwWPx46UDfrnshYDXBvGHSYqkFtn4MQ8Gatf67w7FzFtHivA+Hb0ZPq56upG8w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
       "dependencies": {
         "protobufjs": "^7.0.0",
-        "uint8arraylist": "^2.3.2"
+        "uint8arraylist": "^2.4.3"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -472,136 +741,12 @@
         "uint8arraylist": "^2.3.2"
       }
     },
-    "node_modules/@libp2p/interface-connection": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.2.tgz",
-      "integrity": "sha512-38R2GQ6BCOtwMi5uWU5MLr+xfEpRmVK9gqOp7jNx+6T7TVn8ji4725XLXNfpzprbOrzZkqf2iER84s8+yX4pMA==",
+    "node_modules/@libp2p/interface-address-manager": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-address-manager/-/interface-address-manager-2.0.4.tgz",
+      "integrity": "sha512-RcSi+z+xpVKJXq3BsfLf2rq8zb8VTAFown6uJBu02towMc0enYqqhwlV9DxcCaC573MgQ7gY2s/3XvxQdFraVA==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
         "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection-encrypter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-1.0.3.tgz",
-      "integrity": "sha512-3HNg52HmanRuV2rbQRMFUVTPceSqoC1+ifK9Jkqw3mbiTXXf1mdsv5uKbqts6QvNY5ABZeQWuqJb2QqibaI0mw==",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "it-stream-types": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/@libp2p/interfaces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-      "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
-      }
-    },
-    "node_modules/@libp2p/interface-keys": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.3.tgz",
-      "integrity": "sha512-K8/HlRl/swbVTWuGHNHF28EytszYfUhKgUHfv8CdbMk9ZA/bgO4uU+d9rcrg/Dhw3511U3aRz2bwl2psn6rJfg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-id": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-1.0.4.tgz",
-      "integrity": "sha512-VRnE0MqmS1kN43hyKCEdkhz0gciuDML7hpL3p8zDm0LnveNMLJsR+/VSUaugCi/muOzLaLk26WffKWbMYfnGfA==",
-      "dependencies": {
-        "multiformats": "^9.6.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-info": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.3.tgz",
-      "integrity": "sha512-QKybxfp/NmDGDMkgf/CTt4fU03ajZnldHr9TYg5wMkJrnVaaHbhDTYBg5YWt+iOH1mgR89/dpKv/Na0ZE5sPIA==",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
         "@multiformats/multiaddr": "^11.0.0"
       },
       "engines": {
@@ -609,77 +754,197 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-peer-info/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
+    "node_modules/@libp2p/interface-connection": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.1.0.tgz",
+      "integrity": "sha512-UfluPclTyJp5nBVKQVJ7Xrwp45fFYeIPuyfCpZfTKOfT/srSntA5l+094H6f1bGSj6SbwZ4V7BxCxviJQM5PBg==",
       "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-peer-info/node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
+    "node_modules/@libp2p/interface-connection-encrypter": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
+      "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
       "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-peer-info/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-info/node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
+    "node_modules/@libp2p/interface-connection-manager": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.3.7.tgz",
+      "integrity": "sha512-GyRa7FXtwjbch4ucFa/jj6vcaQT2RyhUbH3q0tIOTzjntABTMzQrhn3BWOGU5deRp2K7cVOB/OzrdhHdGUxYQA==",
       "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
       },
       "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-peer-info/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
+    "node_modules/@libp2p/interface-content-routing": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.0.2.tgz",
+      "integrity": "sha512-SlyZnBk+IpTKdT/4RMNTHcl18PRWUXfb3qhkBPP8xBNGm57DxApKQjLjoklSRNwJ3VDmXyPqTpiR/K/pLPow6A==",
+      "dependencies": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-dht": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-dht/-/interface-dht-2.0.1.tgz",
+      "integrity": "sha512-+yEbt+1hMTR1bITzYyE771jEujimPXqDyFm8T1a8slMpeOD9z5wmLfuCWif8oGZJzXX5YqldWwSwytJQgWXL9g==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keychain": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.4.tgz",
+      "integrity": "sha512-RCH0PL9um/ejsPiWIOzxFzjPzL2nT2tRUtCDo1aBQqoBi7eYp4I4ya1KbzgWDPTmNuuFtCReRMQsZ7/KVirKPA==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keys": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.7.tgz",
+      "integrity": "sha512-DRMPY9LfcnGJKrjaqIkY62U3fW2dya3VLy4x986ExtMrGn4kxIHeQ1IKk8/Vs9CJHTKmXEMID4of1Cjnw4aJpA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-libp2p": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-libp2p/-/interface-libp2p-1.1.1.tgz",
+      "integrity": "sha512-cELZZv/tzFxbUzL3Jvbk+AM2J6kDhIUNBIMMMLuR3LIHfmVJkh31G3ChLUZuKhBwB8wXJ1Ssev3fk1tfz/5DWA==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interface-keychain": "^2.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interface-peer-routing": "^1.0.0",
+        "@libp2p/interface-peer-store": "^1.0.0",
+        "@libp2p/interface-pubsub": "^3.0.0",
+        "@libp2p/interface-registrar": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
+      "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-discovery": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-discovery/-/interface-peer-discovery-1.0.5.tgz",
+      "integrity": "sha512-R0TN/vDaCJLvRhop0y4qoPqapHxX4AEQDEtqmpayAA1BuPgbBq4fS4mepR3FAMcNva/szeqVCDuI4gDejtCaVg==",
+      "dependencies": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-info": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.8.tgz",
+      "integrity": "sha512-LRvZt/9bZFYW7seAwuSg2hZuPl+FRTAsij5HtyvVwmpfVxipm6yQrKjQ+LiK/SZhIDVsSJ+UjF0mluJj+jeAzQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-routing": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.0.8.tgz",
+      "integrity": "sha512-ArJWymWvHqVNyHSZ+7T9av2A4r0f1zTPMKe3+7BOX3n2mB8hP2nNMz/Kiun41TH0t80zMiXE73ZD29is27yt9g==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/interface-peer-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.2.tgz",
-      "integrity": "sha512-ZjE9AkDtjz4R+SppCgZ66oko7Z9pDsdFk1lbba0hTPA2i0uuWdTYep7bZ3RvKot0Q2UrWg8ySL/30pW+Wp70sA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.8.tgz",
+      "integrity": "sha512-FM9VLmpg9CUBKZ2RW+J7RrQfQVMksLiC8oqENqHgb/VkPJY3kafbn7HIi0NcK6H/H5VcwBIhL15SUJk66O1K6g==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-peer-info": "^1.0.0",
         "@libp2p/interface-record": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
@@ -690,87 +955,56 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-peer-store/node_modules/@libp2p/interfaces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-      "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-store/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
+    "node_modules/@libp2p/interface-pubsub": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.6.tgz",
+      "integrity": "sha512-c1aVHAhxmEh9IpLBgJyCsMscVDl7YUeP1Iq6ILEQoWiPJhNpQqdfmqyk7ZfrzuBU19VFe1EqH0bLuLDbtfysTQ==",
       "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-pushable": "^3.0.0",
+        "uint8arraylist": "^2.1.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-store/node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-store/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-store/node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-store/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
       }
     },
     "node_modules/@libp2p/interface-record": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.1.tgz",
-      "integrity": "sha512-RqF5jKukI8v3Q8MZb4d8/UVjg0OXbl0R8ErWi/LKf+uklA8kTA7rT4FQXFUBycxrkFmEu/tJnW+R1/4fwRwZVg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.6.tgz",
+      "integrity": "sha512-4EtDkY3sbYapWM8++gVHlv31HZXoLmj9I7CRXUKXzFkVE0GLK/A8jYWl7K0lmf2juPjeYm2eHITeA9/wAtIS3w==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "uint8arraylist": "^2.0.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-registrar": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.9.tgz",
+      "integrity": "sha512-+aZg7SB8fIddE4/PojnHY2Y29vwr4YtnXxro3db/TYWAsWNGlgZusFEZYqBMpV/1KpEFBdi3O7r50bv/2fRusQ==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.5.tgz",
+      "integrity": "sha512-815aJ+qVswNcTEOuOUTcB+7OLzAfROyjjqoWpK0bD0P/xqTHqOQcqdaDuK02zPuAZqYq9uR3+SoBasrCg6k3zw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-stream-types": "^1.0.4"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -778,11 +1012,12 @@
       }
     },
     "node_modules/@libp2p/interface-transport": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-1.0.4.tgz",
-      "integrity": "sha512-MOkhtykUrrbgHC1CcAFe/6QTz/BEBbHfu5sf+go6dhBlHXeHI+AcV8Fic5zTZNz71E1SRi2UR+5TVi7ORPL57Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.1.tgz",
+      "integrity": "sha512-xDM/s8iPN/XfNqD9qNelibRMPKkhOLinXwQeNtoTZjarq+Cg6rtO6/5WBG/49hyI3+r+5jd2eykjPGQbb86NFQ==",
       "dependencies": {
         "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
         "@libp2p/interfaces": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0",
         "it-stream-types": "^1.0.4"
@@ -792,106 +1027,24 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-transport/node_modules/@libp2p/interfaces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-      "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-transport/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-transport/node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-transport/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/interface-transport/node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/interface-transport/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
-      }
-    },
     "node_modules/@libp2p/interfaces": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-2.0.4.tgz",
-      "integrity": "sha512-MfwkTFyHJtvwNxkjOjzkXyIVvKFtEW2Q3IGRJPyPQMrtB6ll0rGMTlyJ3BQS1bcD0YkNhggFm+8XiU2/0LCBhQ==",
-      "dependencies": {
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-pushable": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "multiformats": "^9.6.3"
-      },
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
+      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.1.tgz",
-      "integrity": "sha512-Mtj7ImjRYbaANuT53QRqc7ooBYpWieLo7KbqYYGas5O2AWQeOu/zyGBMM35WbWIo7sMuhCas9XBPJdFOR7A05w==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.6.tgz",
+      "integrity": "sha512-PfTGCBT6buiGeww7heG1JucBK2io2sJ2hntNh+gTVohRy4FyEvZixnWfIVD2rCM8EsbZu3Hmt/qqetzX5BrziQ==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.2",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "debug": "^4.3.3",
-        "interface-datastore": "^7.0.0",
-        "multiformats": "^9.6.3"
+        "interface-datastore": "^8.0.0",
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -899,13 +1052,13 @@
       }
     },
     "node_modules/@libp2p/logger/node_modules/interface-datastore": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.0.tgz",
-      "integrity": "sha512-q9OveOhexQ3Fx8h4YbuR4mZtUHwvlOynKnIwTm6x8oBTWfIyAKtlYtrOYdlHfqQztbYpdzRFcapopNJBMx36NQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.0.0.tgz",
+      "integrity": "sha512-RRkUskUnBn4q6pGCMgc3j4t+MxVgj6SNADQPna63/MOvYk36yxj3sJh/8Apj8MLAMtzCosXhbCi82S/9W1z3qg==",
       "dependencies": {
-        "interface-store": "^3.0.0",
-        "nanoid": "^3.0.2",
-        "uint8arrays": "^3.0.0"
+        "interface-store": "^4.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -913,45 +1066,44 @@
       }
     },
     "node_modules/@libp2p/logger/node_modules/interface-store": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.0.tgz",
-      "integrity": "sha512-IBJn3hE6hYutwdDcStR76mcwfV98vZc49LkEN9ANHHpsxcm6YbGMJxowO2G3FITU4U5ZH4KJPlHOT6Oe2vzTWA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-4.0.0.tgz",
+      "integrity": "sha512-cApTZjtMixGyIVNKw6cFcPJTL0KLEbUslhn7hzaKRonQqjjQxzEnklGZkreqmgbVlwOPLQ06s0Qg6F1yOYzfow==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/nanoid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+      "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww==",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/@libp2p/mplex": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-1.2.2.tgz",
-      "integrity": "sha512-+DHxpxGpnCAvy/q/G2YJY121NMBS3+065DcQkPfFe+hToqmgO9sSJmZbFeOm/AYpauchvVSUvS75dxGdgQ4R9Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.1.tgz",
+      "integrity": "sha512-0owK1aWgXXtjiohXtjwLV7Ehjdj96eBtsapVt7AzlHA+W8uYnI+x058thq3MisyMDlHiiE3BTh6fEf+t2/0dUw==",
       "dependencies": {
-        "@libp2p/logger": "^1.1.3",
-        "@libp2p/tracked-map": "^1.0.5",
+        "@libp2p/interface-connection": "^3.0.1",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/logger": "^2.0.0",
         "abortable-iterator": "^4.0.2",
         "any-signal": "^3.0.0",
+        "benchmark": "^2.1.4",
         "err-code": "^3.0.1",
-        "it-pipe": "^2.0.3",
-        "it-pushable": "^3.0.0",
+        "it-batched-bytes": "^1.0.0",
+        "it-pushable": "^3.1.0",
         "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.4.0",
-        "uint8arrays": "^3.0.0",
+        "rate-limiter-flexible": "^2.3.9",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/mplex/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -963,87 +1115,47 @@
       "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
       "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
     },
-    "node_modules/@libp2p/mplex/node_modules/it-pipe": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-      "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
-      "dependencies": {
-        "it-merge": "^1.0.4",
-        "it-pushable": "^3.1.0",
-        "it-stream-types": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/mplex/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-    },
-    "node_modules/@libp2p/mplex/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/multistream-select": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-1.0.6.tgz",
-      "integrity": "sha512-8veeiZDrh7aCvILjNGps4ZLKSKTdBxJZS4SZkuhbCKmq7eX6aJoYoQ5G5MBxEFiBKtgwTKHaSroH3jfvizwDoA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-3.1.2.tgz",
+      "integrity": "sha512-NfF0fwQM4sqiLuNGBVc9z2mfz3OigOfyLJ5zekRBGYHkbKWrBRFS3FligUPr9roCOzH6ojjDkKVd5aK9/llfJQ==",
       "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
+        "@libp2p/interfaces": "^3.0.2",
+        "@libp2p/logger": "^2.0.0",
         "abortable-iterator": "^4.0.2",
         "err-code": "^3.0.1",
-        "it-first": "^1.0.6",
-        "it-handshake": "^3.0.1",
-        "it-length-prefixed": "^7.0.1",
-        "it-pipe": "^2.0.3",
-        "it-pushable": "^2.0.1",
-        "it-reader": "^5.0.0",
+        "it-first": "^2.0.0",
+        "it-handshake": "^4.1.2",
+        "it-length-prefixed": "^8.0.3",
+        "it-merge": "^2.0.0",
+        "it-pipe": "^2.0.4",
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
         "it-stream-types": "^1.0.4",
         "p-defer": "^4.0.0",
-        "uint8arraylist": "^1.5.1",
-        "uint8arrays": "^3.0.0"
+        "uint8arraylist": "^2.3.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/multistream-select/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
-      },
+    "node_modules/@libp2p/multistream-select/node_modules/it-first": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
+      "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/multistream-select/node_modules/it-handshake": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-3.0.1.tgz",
-      "integrity": "sha512-Rx9ESanlfnC0aMw2LtLJ9YNlCNgnZU7wOHPzPSZTUAjbdZx54kllGR5ndIuoJqF2EtNIsmTiWEncKTgwHNJSSg==",
+    "node_modules/@libp2p/multistream-select/node_modules/it-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+      "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
       "dependencies": {
-        "it-map": "^1.0.6",
-        "it-pushable": "^2.0.1",
-        "it-reader": "^5.0.0",
-        "it-stream-types": "^1.0.4",
-        "p-defer": "^4.0.0"
+        "it-pushable": "^3.1.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1051,11 +1163,11 @@
       }
     },
     "node_modules/@libp2p/multistream-select/node_modules/it-pipe": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-      "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
       "dependencies": {
-        "it-merge": "^1.0.4",
+        "it-merge": "^2.0.0",
         "it-pushable": "^3.1.0",
         "it-stream-types": "^1.0.3"
       },
@@ -1064,43 +1176,13 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/multistream-select/node_modules/it-pipe/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-    },
-    "node_modules/@libp2p/multistream-select/node_modules/it-reader": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-5.0.2.tgz",
-      "integrity": "sha512-OgcWA/ffAALrkuUN2sQsbKa3of5oOyLvlXJgSCZdn9sSLZ0rnNmtsJ3lP/WEfWJH8aUNs3bfG6ja3QXKcCOwFw==",
-      "dependencies": {
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/multistream-select/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/peer-collections": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-2.2.0.tgz",
-      "integrity": "sha512-fLHWRms2aiSplZcTfXz6bLGZ62f1jfcW3EkS/TweVRpbWpzbtkW+V1CKkhlF3Qc4pJl7GTA5HAfPWIrVDvBYag==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-3.0.0.tgz",
+      "integrity": "sha512-rVhfDmkVzfBVR4scAfaKb05htZENx01PYt2USi1EnODyoo2c2U2W5tfOfyaKI/4D+ayQDOjT27G0ZCyAgwkYGw==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.4",
-        "@libp2p/peer-id": "^1.1.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1108,14 +1190,14 @@
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-1.1.15.tgz",
-      "integrity": "sha512-Y33JLEfsLmLUjuC2nhQ2lBXP6PIsR892gSsNy4Vd7oILkuRhjPouIojP9BbME0m9bhVbAws+Zh9NBKtp7UH7wA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.2.tgz",
+      "integrity": "sha512-RBjCMtSLnX43OK6zIpMW/cKzEgnsunihgyVPhnB/U7DAAEnovxe8F1Q4jBQp9+9DYSgQJrsdiEBpT5JH0Eh2lA==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "err-code": "^3.0.1",
-        "multiformats": "^9.6.3",
-        "uint8arrays": "^3.0.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1123,18 +1205,18 @@
       }
     },
     "node_modules/@libp2p/peer-id-factory": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-1.0.18.tgz",
-      "integrity": "sha512-x7lyPrfF4kkMj6az+h1sq5L6ifTvZt2exKi8yS6/Gi/hT8rfqXROdBDtanMjJivIFlzVKJyZdfW5f5RK9Av3iQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.2.tgz",
+      "integrity": "sha512-cnny4gkZf1HQ7aZVeZii3xY4DBSPW+O29GvnhECRF55SkRa5xzkZMVnoKX2d+9wBbS4t3ng2kOF2HtgSIySfWw==",
       "dependencies": {
         "@libp2p/crypto": "^1.0.0",
         "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "@libp2p/peer-id": "^1.0.0",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^3.1.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1142,12 +1224,12 @@
       }
     },
     "node_modules/@libp2p/peer-id-factory/node_modules/protons-runtime": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-3.1.0.tgz",
-      "integrity": "sha512-S1iSPQC0McdHKJRi0XcATBkWgwWPx46UDfrnshYDXBvGHSYqkFtn4MQ8Gatf67w7FzFtHivA+Hb0ZPq56upG8w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
       "dependencies": {
         "protobufjs": "^7.0.0",
-        "uint8arraylist": "^2.3.2"
+        "uint8arraylist": "^2.4.3"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1158,233 +1240,163 @@
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-1.0.12.tgz",
-      "integrity": "sha512-1b4aeU4sduRBUH4RKDtYBHKOEXwohrlOoBrrNPKb1WFweLMnG3oznhGusMvKQ8YuXSOTpbNPHrbJ/iJnrBbVUQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.2.tgz",
+      "integrity": "sha512-Cqaj3pC9zQHKE1FYE7B1OcMVWQkQNjLaSH2ioavz3PMPWGy+5m4dVK9hvSyoEf8PfRKFT+x92MONbappEFBwvg==",
       "dependencies": {
-        "@libp2p/crypto": "^0.22.8",
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@libp2p/peer-id": "^1.1.0",
-        "@libp2p/utils": "^1.0.9",
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-filter": "^1.0.3",
-        "it-foreach": "^0.1.1",
-        "it-map": "^1.0.6",
-        "it-pipe": "^2.0.3",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/utils": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.2",
+        "uint8arraylist": "^2.1.0",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/@libp2p/crypto": {
-      "version": "0.22.14",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-0.22.14.tgz",
-      "integrity": "sha512-5RyGh5ovfqrDD8Io3n5rvVnsTHBf1exIMZ/5eBw7Eoy21xkmzdF1Hy701SoSNmiCuTPXYmxT5WMy2VUDBUG6oQ==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.1",
-        "@noble/ed25519": "^1.6.0",
-        "@noble/secp256k1": "^1.5.4",
-        "err-code": "^3.0.1",
-        "iso-random-stream": "^2.0.0",
-        "multiformats": "^9.4.5",
-        "node-forge": "^1.1.0",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/@libp2p/utils": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-1.0.10.tgz",
-      "integrity": "sha512-jlVLfac1IoBlgXL8V+XZYxNw0SOAkKweiLhXWolUbKOgRtMDquJzbwG1n8y9GtdiFKPlkiBwOB7l9xighcOR6w==",
-      "dependencies": {
-        "@achingbrain/ip-address": "^8.1.0",
-        "@libp2p/logger": "^1.0.1",
-        "@multiformats/multiaddr": "^10.1.1",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "is-loopback-addr": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
-        "ts-mocha": "^9.0.2",
-        "ts-node": "^10.7.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/it-pipe": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-      "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
-      "dependencies": {
-        "it-merge": "^1.0.4",
-        "it-pushable": "^3.1.0",
-        "it-stream-types": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
     },
     "node_modules/@libp2p/peer-record/node_modules/protons-runtime": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-      "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
       "dependencies": {
-        "uint8arraylist": "^1.4.0",
-        "uint8arrays": "^3.0.0"
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
       },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/@libp2p/peer-store": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-1.0.17.tgz",
-      "integrity": "sha512-1uvwjJ2dRQyQnms+vBY3CgWpZe+0EYSoCNo7UUE6dhJHIA3q1Syl4kZWukA081m1eFzmMLG2VjsrzUQAfmy+Sw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-6.0.4.tgz",
+      "integrity": "sha512-yw7XbeJ5k880PpkDV/HcSZtj0vQ0ShPbnCzVHc1hW0JS/g1vhpSooAZOf3w65obUoFhUwccnSZ4HSLBSpQqOaA==",
       "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@libp2p/peer-id": "^1.1.0",
-        "@libp2p/peer-record": "^1.0.0",
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-filter": "^1.0.3",
-        "it-foreach": "^0.1.1",
-        "it-map": "^1.0.6",
-        "it-pipe": "^2.0.3",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-store": "^1.2.2",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-foreach": "^1.0.0",
+        "it-map": "^2.0.0",
         "mortice": "^3.0.0",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0"
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/peer-store/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
+    "node_modules/@libp2p/peer-store/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
       "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/peer-store/node_modules/it-pipe": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-      "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
-      "dependencies": {
-        "it-merge": "^1.0.4",
-        "it-pushable": "^3.1.0",
-        "it-stream-types": "^1.0.3"
-      },
+    "node_modules/@libp2p/peer-store/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/peer-store/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
+    "node_modules/@libp2p/peer-store/node_modules/it-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/it-filter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+      "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/it-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+      "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/nanoid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+      "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww==",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
     },
     "node_modules/@libp2p/peer-store/node_modules/protons-runtime": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-      "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
       "dependencies": {
-        "uint8arraylist": "^1.4.0",
-        "uint8arrays": "^3.0.0"
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-store/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
       },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/@libp2p/tcp": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-3.1.2.tgz",
-      "integrity": "sha512-b2xrzmAx0ktlgzsSgaqeHjtnVNzZeYPZPtgjbGub9zEWHZFuN4XER9XppdCMbvQw/68RHufuSQu8PEDMv5l4VQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-6.1.2.tgz",
+      "integrity": "sha512-IKxcAO4qHRgGLT2aqsy2ayUmkra38efJ5mla4lDECjxcUqHnbok+QEPIgDodPbTaEgfbd6ivmwP1YxHLxt9dJA==",
       "dependencies": {
         "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-transport": "^1.0.4",
-        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-transport": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/utils": "^3.0.2",
         "@multiformats/mafmt": "^11.0.3",
         "@multiformats/multiaddr": "^11.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
         "stream-to-it": "^0.2.2"
       },
       "engines": {
@@ -1392,86 +1404,12 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/tcp/node_modules/@libp2p/interfaces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-      "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/tcp/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/tcp/node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/tcp/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/tcp/node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/tcp/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
-      }
-    },
     "node_modules/@libp2p/tracked-map": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-1.0.8.tgz",
-      "integrity": "sha512-tN56iEdSbDuUhDApQV0k93aIQu/vACN8fNHsaWZrFpvwPaXmLb//jn3m34pwnSyaTPjUSendP25+JDzg/2U/mw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-3.0.2.tgz",
+      "integrity": "sha512-mtsZWf2ntttuCrmEIro2p1ceCAaKde2TzT/99DZlkGdJN/Mo1jZgXq7ltZjWc8G3DAlgs+0ygjMzNKcZzAveuQ==",
       "dependencies": {
-        "@libp2p/interfaces": "^2.0.0"
+        "@libp2p/interface-metrics": "^4.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1479,9 +1417,9 @@
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.2.tgz",
-      "integrity": "sha512-/+mwCEd1o1sko3fYkVfy9pDT3Ks+KszR4Y3fb3M3/UCETDituvqZKHHM4wyTJsFlrFrohbtYlNvWhJ7Pej3X5g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.4.tgz",
+      "integrity": "sha512-EWJNJtlop2ylmGE1BNiMA0u4eTLKoY0LbZ/DOvSDs9VlGSLua9J+LUjp6XV8lazGv7l1rOLiU+1hP5fcmg1+eg==",
       "dependencies": {
         "@achingbrain/ip-address": "^8.1.0",
         "@libp2p/interface-connection": "^3.0.2",
@@ -1492,7 +1430,7 @@
         "err-code": "^3.0.1",
         "is-loopback-addr": "^2.0.1",
         "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
+        "private-ip": "^3.0.0",
         "uint8arraylist": "^2.3.2"
       },
       "engines": {
@@ -1500,78 +1438,13 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/utils/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/utils/node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/utils/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/utils/node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/utils/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
-      }
-    },
     "node_modules/@libp2p/websockets": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-3.0.4.tgz",
-      "integrity": "sha512-Xu2ENTcc05D+QALo7ayVlMJjKPUoABToUve1JQQmfH2Pb6ck1fACmjLTTpumoRDNm6UZTbkW1k8SgUmzg57iiw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.5.tgz",
+      "integrity": "sha512-gp6OI/2cBBkbUKw7XougNC8/XZe1fe5eSngWDSE99/wGykwDzyKPnYikUAGhJ4X1VuBDAjogZuJp7PtDif1QPQ==",
       "dependencies": {
         "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-transport": "^1.0.4",
+        "@libp2p/interface-transport": "^2.0.0",
         "@libp2p/interfaces": "^3.0.3",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/utils": "^3.0.2",
@@ -1579,95 +1452,21 @@
         "@multiformats/multiaddr": "^11.0.0",
         "@multiformats/multiaddr-to-uri": "^9.0.2",
         "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "it-ws": "^5.0.0",
+        "it-ws": "^5.0.6",
         "p-defer": "^4.0.0",
         "p-timeout": "^6.0.0",
-        "wherearewe": "^2.0.1"
+        "wherearewe": "^2.0.1",
+        "ws": "^8.12.1"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/websockets/node_modules/@libp2p/interfaces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-      "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/websockets/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/websockets/node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/websockets/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/websockets/node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/websockets/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
       }
     },
     "node_modules/@libp2p/websockets/node_modules/p-timeout": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
-      "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
+      "integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w==",
       "engines": {
         "node": ">=14.16"
       },
@@ -1676,13 +1475,13 @@
       }
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.10.0.tgz",
-      "integrity": "sha512-nzEqFVPnD7Yf0HMDv7gCPpf4NSXfjhc+zg3gSwUS4Dad5bWV10B1ujTZW6HxQulW3CBHIg616mTjXIiaimVuEQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.9.0.tgz",
+      "integrity": "sha512-lriPxUEva9TJ01vU9P7pI60s3SsFnb4apWkNwZ+D7CRqyXPipSbapY8BWI2FUIwkEG7xap6UhzeTS76NettCXQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "5.9.1"
       },
@@ -1691,12 +1490,12 @@
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.10.0.tgz",
-      "integrity": "sha512-NAiCtqlHTUKCmV+Jl9af+ixGmMhiGhIyIfr/vCdbismNEBxEsrQGg3sQYTNfvCkdHtODurQqayQreFq21OuEow==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.9.0.tgz",
+      "integrity": "sha512-gu8Z7NWNcYw6514/yOvajaj3GmebRucx+EEt3p1vKirO+gvFgKAt/puyUN3p7u8ZZmLuLF/B+wVnH3lj8BWKlg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/shared": "2.9.0",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -1704,15 +1503,15 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-Jx1M5oXQua0jzsJVdZSq07baVRmGC/6JkglrPQGAlZ7gQ1sunVZzq9fjxFqj0bqfEuYS0Wy6+lvK4rOAHISIjw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-QqSwF6oHvgrFvN5lnrLc6EEagFlZWW+UMU8QdrE8305cNGHrIOxKCA2nte4PVFZUVw/Ts13a0tVhUk3a2fAyxQ==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/watcher": "2.10.0",
+        "@miniflare/queues": "2.9.0",
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/watcher": "2.9.0",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -1725,27 +1524,27 @@
       }
     },
     "node_modules/@miniflare/d1": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.10.0.tgz",
-      "integrity": "sha512-mOYZSmpTthH0tmFTQ+O9G0Q+iDAd7oiUtoIBianlKa9QiqYAoO7EBUPy6kUgDHXapOcN5Ri1u3J5UTpxXvw3qg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.9.0.tgz",
+      "integrity": "sha512-swK9nzxw1SvVh/4cH3bRR1SBuHQU/YsB8WvuHojxufmgviAD1xhms3XO3rkpAzfKoGM5Oy6DovMe0xUXV/GS0w==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.10.0.tgz",
-      "integrity": "sha512-gU45f52gveFtCasm0ixYnt0mHI1lHrPomtmF+89oZGKBzOqUfO5diDs6wmoRSnovOWZCwtmwQGRoorAQN7AmoA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.9.0.tgz",
+      "integrity": "sha512-7uTvfEUXS7xqwrsWOwWrFUuKc4EiMpVkAWPeYGLB/0TJaJ6N+sZMpYYymdW79TQwPIDfgtpfkIy93MRydqpnrw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/storage-memory": "2.9.0",
         "undici": "5.9.1"
       },
       "engines": {
@@ -1753,13 +1552,13 @@
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.10.0.tgz",
-      "integrity": "sha512-hCdG99L8+Ros4dn3B5H37PlQPBH0859EoRslzNTd4jzGIkwdiawpJvrvesL8056GjbUjeJN1zh7OPBRuMgyGLw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.9.0.tgz",
+      "integrity": "sha512-K5OB70PtkMo7M+tU46s/cX/j/qtjD9AlJ0hecYswrxVsfrT/YWyrCQJevmShFfJ92h7jPNigbeC3Od3JiVb6QA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "5.9.1"
       },
@@ -1768,14 +1567,14 @@
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.10.0.tgz",
-      "integrity": "sha512-cm6hwkONucll93yoY8dteMp//Knvmb7n6zAgeHrtuNYKn//lAL6bRY//VLTttrMmfWxZFi1C7WpOeCv8Mn6/ug==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.9.0.tgz",
+      "integrity": "sha512-IVJMkFfMpecq9WiCTvATEKhMuKPK9fMs2E6zmgexaefr3u1VlNtj2QxBxoPUXkT9xMJQlT5sSKstlRR1XKDz9Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/web-sockets": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/web-sockets": "2.9.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "5.9.1",
@@ -1787,36 +1586,36 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.10.0.tgz",
-      "integrity": "sha512-3+u1lO77FnlS0lQ6b1VgM1E/ZgQ/zy/FU+SdBG5LUOIiv3x522VYHOApeJLnSEo0KtZUB22Ni0fWQM6DgpaREg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.9.0.tgz",
+      "integrity": "sha512-EqG51okY5rDtgjYs2Ny6j6IUVdTlJzDjwBKBIuW+wOV9NsAAzEchKVdYAXc8CyxvkggpYX481HydTD2OzK3INQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.9.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/queues": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.10.0.tgz",
-      "integrity": "sha512-WKdO6qI9rfS96KlCjazzPFf+qj6DPov4vONyf18+jzbRjRJh/xwWSk1/1h5A+gDPwVNG8TsNRPh9DW5OKBGNjw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.9.0.tgz",
+      "integrity": "sha512-cAHWIlLF57rxQaJl19AzXw1k0SOM/uLTlx8r2PylHajZ/RRSs7CkCox3oKA6E5zKyfyxk2M64bmsAFZ9RCA0gw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.9.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/r2": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.10.0.tgz",
-      "integrity": "sha512-uC1CCWbwM1t8DdpZgrveg6+CkZLfTq+wUMqs20BC5rCT8u8UyRv6ZVRQ7pTPiswLyt1oYDTXsZJK7tjV0U0zew==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.9.0.tgz",
+      "integrity": "sha512-aMFWxxciAE3YsVok2OLy3A7hP5+2j/NaK7txmadgoe1CA8HYZyNuvv7v6bn8HKM5gWnJdT8sk4yEbMbBQ7Jv/A==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/shared": "2.9.0",
         "undici": "5.9.1"
       },
       "engines": {
@@ -1824,25 +1623,25 @@
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.10.0.tgz",
-      "integrity": "sha512-oTsHitQdQ1B1kT3G/6n9AEXsMd/sT1D8tLGzc7Xr79ZrxYxwRO0ATF3cdkxk4dUjUqg/RUqvOJV4YjJGyqvctg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.9.0.tgz",
+      "integrity": "sha512-vewP+Fy7Czb261GmB9x/YtQkoDs/QP9B5LbP0YfJ35bI2C2j940eJLm8JP72IHV7ILtWNOqMc3Ure8uAbpf9NQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.9.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.10.0.tgz",
-      "integrity": "sha512-eGt2cZFE/yo585nT8xINQwdbTotZfeRIh6FUWmZkbva1i5SW0zTiOojr5a95vAGBF3TzwWGsUuzJpLhBB69a/g==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.9.0.tgz",
+      "integrity": "sha512-eodSCGkJYi4Z+Imbx/bNScDfDSt5HOypVSYjbFHj+hA2aNOdkGw6a1b6mzwx49jJD3GadIkonZAKD0S114yWMA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -1850,9 +1649,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.10.0.tgz",
-      "integrity": "sha512-GDSweEhJ3nNtStGm6taZGUNytM0QTQ/sjZSedAKyF1/aHRaZUcD9cuKAMgIbSpKfvgGdLMNS7Bhd8jb249TO7g==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.9.0.tgz",
+      "integrity": "sha512-5Ew/Ph0cHDQqKvOlmN70kz+qZW0hdgE9fQBStKLY3vDYhnBEhopbCUChSS+FCcL7WtxVJJVE7iB6J09NQTnQ/A==",
       "dev": true,
       "dependencies": {
         "@types/better-sqlite3": "^7.6.0",
@@ -1865,64 +1664,64 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.10.0.tgz",
-      "integrity": "sha512-1NVAT6+JS2OubL+pOOR5E/6MMddxQHWMi/yIDSumyyfXmj7Sm7n5dE1FvNPetggMP4f8+AjoyT9AYvdd1wkspQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.9.0.tgz",
+      "integrity": "sha512-+tWf7znxSQqXWGzPup8Xqkl8EmLmx+HaLC+UBtWPNnaJZrsjbbVxKwHpmGIdm+wZasEGfQk/82R21gUs9wdZnw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/kv": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-file": "2.10.0"
+        "@miniflare/kv": "2.9.0",
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/storage-file": "2.9.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.10.0.tgz",
-      "integrity": "sha512-K/cRIWiTl4+Z+VO6tl4VfuYXA3NLJgvGPV+BCRYD7uTKuPYHqDMErtD1BI1I7nc3WJhwIXfzJrAR3XXhSKKWQQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.9.0.tgz",
+      "integrity": "sha512-HZHtHfJaLoDzQFddoIMcDGgAJ3/Nee98gwUYusQam7rj9pbEXnWmk54dzjzsDlkQpB/3MBFQNbtN5Bj1NIt0pg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0"
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/storage-memory": "2.9.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.10.0.tgz",
-      "integrity": "sha512-ZATU+qZtJ9yG0umgTrOEUi9SU//YyDb8nYXMgqT4JHODYA3RTz1SyyiQSOOz589upJPdu1LN+0j8W24WGRwwxQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.9.0.tgz",
+      "integrity": "sha512-p2yrr0omQhv6teDbdzhdBKzoQAFmUBMLEx+PtrO7CJHX15ICD08/pFAFAp96IcljNwZZDchU20Z3AcbldMj6Tw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.9.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.10.0.tgz",
-      "integrity": "sha512-X9CFYYyszfSYDzs07KhbWC2i08Dpyh3D60fPonYZcoZAfa5h9eATHUdRGvNCdax7awYp4b8bvU8upAI//OPlMg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.9.0.tgz",
+      "integrity": "sha512-Yqz8Q1He/2chebXvmCft8sMamuUiDQ4FIn0bwiF0+GBP2vvGCmy6SejXZY4ZD4REluPqQSis3CLKcIOWlHnIsw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.9.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.10.0.tgz",
-      "integrity": "sha512-W+PrapdQqNEEFeD+amENgPQWcETGDp7OEh6JAoSzCRhHA0OoMe8DG0xb5a5+2FjGW/J7FFKsv84wkURpmFT4dQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.9.0.tgz",
+      "integrity": "sha512-Nob9e84m78qeQCka6OQf/JdNOmMkKCkX+i3rg+TYKSSITiMVuyzWp3vz3Ma184lAZiLg44lxBF4ZzENEdi99Kg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
         "undici": "5.9.1",
         "ws": "^8.2.2"
       },
@@ -1931,9 +1730,9 @@
       }
     },
     "node_modules/@multiformats/mafmt": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.0.3.tgz",
-      "integrity": "sha512-DvCQeZJgaC4kE3BLqMuW3gQkNAW14Z7I+yMt30Ze+wkfHkWSp+bICcHGihhtgfzYCumHA/vHlJ9n54mrCcmnvQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.1.0.tgz",
+      "integrity": "sha512-ZGuP26SIbBZutDN/QhqGwuu7b1zTO9DLvG4l3fh15ambPmcwS811MQIyW+d+9Vl7ASheB0qJq0sJrMKsHS3dXA==",
       "dependencies": {
         "@multiformats/multiaddr": "^11.0.0"
       },
@@ -1942,81 +1741,16 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@multiformats/mafmt/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/mafmt/node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/mafmt/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@multiformats/mafmt/node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@multiformats/mafmt/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
-      }
-    },
     "node_modules/@multiformats/multiaddr": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.5.0.tgz",
-      "integrity": "sha512-u4qHMyv25iAqCb9twJROoN1M8UDm8bureOCIzwz03fVhwJzV6DpgH1eFz9UAzDn7CpSShQ9SLS5MiC4hJjTfig==",
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
       "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
         "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
       },
       "engines": {
@@ -2036,109 +1770,19 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
-      }
-    },
     "node_modules/@multiformats/multiaddr/node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
+      "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
       "dependencies": {
         "debug": "^4.3.1",
         "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@multiformats/multiaddr/node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@multiformats/multiaddr/node_modules/native-fetch": {
@@ -2149,19 +1793,37 @@
         "undici": "*"
       }
     },
+    "node_modules/@multiformats/multiaddr/node_modules/undici": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/@multiformats/murmur3": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
       "integrity": "sha512-wAPLUErGR8g6Lt+bAZn6218k9YQPym+sjszsXL6o4zfxbA22P+gxWZuuD9wDbwL55xrKO5idpcuQUX7/E3oHcw==",
+      "dev": true,
       "dependencies": {
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
       }
     },
+    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true
+    },
     "node_modules/@noble/ed25519": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
-      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
       "funding": [
         {
           "type": "individual",
@@ -2170,9 +1832,9 @@
       ]
     },
     "node_modules/@noble/secp256k1": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
       "funding": [
         {
           "type": "individual",
@@ -2395,30 +2057,10 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
-    },
     "node_modules/@types/better-sqlite3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
-      "integrity": "sha512-RgmaapusqTq6IMAr4McMyAsC6RshYTCjXCnzwVV59WctUxC8bNPyUfT9t5F81lKcU41lLurhjqjoMHfauzfqGg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
+      "integrity": "sha512-YS64N9SNDT/NAvou3QNdzAu3E2om/W/0dhORimtPGLef+zSK5l1vDzfsWb4xgXOgfhtOI5ZDTRxnvRPb22AIVQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -2428,12 +2070,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -2469,12 +2112,6 @@
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
       "dev": true
     },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "peer": true
-    },
     "node_modules/@web-std/blob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.4.tgz",
@@ -2494,56 +2131,21 @@
         "web-streams-polyfill": "^3.1.1"
       }
     },
-    "node_modules/@web3-storage/fast-unixfs-exporter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/fast-unixfs-exporter/-/fast-unixfs-exporter-0.2.1.tgz",
-      "integrity": "sha512-ylJN3q6/H2IiDaFLXdDSnSx02dFaa7EqSZGCKN20TlSk0ZvBbQ9BXs1q/arik64KZ/OqtLMwBivehMs+dUO7Gg==",
-      "dependencies": {
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-pb": "^2.0.2",
-        "@multiformats/murmur3": "^1.0.3",
-        "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "interface-blockstore": "^2.0.3",
-        "ipfs-unixfs": "^6.0.0",
-        "it-last": "^1.0.5",
-        "multiformats": "^9.4.2",
-        "p-queue": "^7.3.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/hamt-sharding": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
-      "integrity": "sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA==",
-      "dependencies": {
-        "sparse-array": "^1.3.1",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@web3-storage/gateway-lib": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-2.0.2.tgz",
-      "integrity": "sha512-bfmJCE6u+Y7jh09KlRFgZnFLHBKvyCcYlqj0n1OV6JLzkl9xrwnMM4kWscsF5+82kElXdwxeRU0cWntM/Ydkkw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-2.0.3.tgz",
+      "integrity": "sha512-pJhL7ReGAhamkwYS6m+XTpHdSJgVaxnRS820nAHmIK9TrVXXj6ejkEKg6ox364ee/5NLDrx4oyEbxCbDGc373w==",
       "dependencies": {
-        "@ipld/car": "^4.1.5",
+        "@ipld/car": "^5.1.0",
         "@web3-storage/handlebars": "^1.0.0",
         "bytes": "^3.1.2",
         "chardet": "^1.5.0",
-        "dagula": "^4.1.0",
+        "dagula": "^5.0.0",
         "magic-bytes.js": "^1.0.12",
         "mrmime": "^1.0.1",
-        "multiformats": "^9.9.0",
+        "multiformats": "^11.0.1",
         "timeout-abort-controller": "^3.0.0",
-        "uint8arrays": "^3.1.1"
+        "uint8arrays": "^4.0.3"
       }
     },
     "node_modules/@web3-storage/gateway-lib/node_modules/retimer": {
@@ -2685,9 +2287,10 @@
       "integrity": "sha512-BDJawD5PU2gZv6Vlp8O28H4GnZcsr3h9gZUvnAP5xXP3WOy/QAoOsyMepSkw21jur+4t5Vppde72ChjhTIzxzg=="
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2708,6 +2311,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2761,9 +2365,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -2780,15 +2384,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -2802,9 +2397,9 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.1.tgz",
-      "integrity": "sha512-qDOv24WjnYuL+wbwHdlsYZFy+cgPtrYw0Tn7GLORicQp9BkQLzrgI3Pm4VyR9ERZ41YTn7KlMPuL1n05WdZvmg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -2827,6 +2422,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2840,15 +2436,11 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-find-index": {
       "version": "1.0.2",
@@ -2945,30 +2537,31 @@
       }
     },
     "node_modules/atomically": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
-      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
-      "engines": {
-        "node": ">=10.12.0"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.1.tgz",
+      "integrity": "sha512-sxBhVZUFBFhqSAsYMM3X2oaUi2NVDJ8U026FsIusM8gYXls9AYs/eXzgGrufs1Qjpkxi9zunds+75QUFz+m7UQ==",
+      "dependencies": {
+        "stubborn-fs": "^1.2.4",
+        "when-exit": "^2.0.0"
       }
     },
     "node_modules/ava": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-4.3.3.tgz",
-      "integrity": "sha512-9Egq/d9R74ExrWohHeqUlexjDbgZJX5jA1Wq4KCTqc3wIfpGEK79zVy4rBtofJ9YKIxs4PzhJ8BgbW5PlAYe6w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-5.2.0.tgz",
+      "integrity": "sha512-W8yxFXJr/P68JP55eMpQIa6AiXhCX3VeuajM8nolyWNExcMDD6rnIWKTjw0B/+GkFHBIaN6Jd0LtcMThcoqVfg==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.7.1",
+        "acorn": "^8.8.1",
         "acorn-walk": "^8.2.0",
-        "ansi-styles": "^6.1.0",
+        "ansi-styles": "^6.2.1",
         "arrgv": "^1.0.2",
         "arrify": "^3.0.0",
         "callsites": "^4.0.0",
         "cbor": "^8.1.0",
-        "chalk": "^5.0.1",
+        "chalk": "^5.2.0",
         "chokidar": "^3.5.3",
         "chunkd": "^2.0.1",
-        "ci-info": "^3.3.1",
+        "ci-info": "^3.7.1",
         "ci-parallel-vars": "^1.0.1",
         "clean-yaml-object": "^0.1.0",
         "cli-truncate": "^3.1.0",
@@ -2977,10 +2570,10 @@
         "concordance": "^5.0.4",
         "currently-unhandled": "^0.4.1",
         "debug": "^4.3.4",
-        "del": "^6.1.1",
-        "emittery": "^0.11.0",
-        "figures": "^4.0.1",
-        "globby": "^13.1.1",
+        "del": "^7.0.0",
+        "emittery": "^1.0.1",
+        "figures": "^5.0.0",
+        "globby": "^13.1.3",
         "ignore-by-default": "^2.1.0",
         "indent-string": "^5.0.0",
         "is-error": "^2.2.2",
@@ -2990,25 +2583,25 @@
         "mem": "^9.0.2",
         "ms": "^2.1.3",
         "p-event": "^5.0.1",
-        "p-map": "^5.4.0",
+        "p-map": "^5.5.0",
         "picomatch": "^2.3.1",
         "pkg-conf": "^4.0.0",
         "plur": "^5.1.0",
-        "pretty-ms": "^7.0.1",
+        "pretty-ms": "^8.0.0",
         "resolve-cwd": "^3.0.0",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.5",
+        "stack-utils": "^2.0.6",
         "strip-ansi": "^7.0.1",
         "supertap": "^3.0.1",
-        "temp-dir": "^2.0.0",
-        "write-file-atomic": "^4.0.1",
-        "yargs": "^17.5.1"
+        "temp-dir": "^3.0.0",
+        "write-file-atomic": "^5.0.0",
+        "yargs": "^17.6.2"
       },
       "bin": {
         "ava": "entrypoints/cli.mjs"
       },
       "engines": {
-        "node": ">=12.22 <13 || >=14.17 <15 || >=16.4 <17 || >=18"
+        "node": ">=14.19 <15 || >=16.15 <17 || >=18"
       },
       "peerDependencies": {
         "@ava/typescript": "*"
@@ -3034,7 +2627,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3056,10 +2650,20 @@
         }
       ]
     },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3100,6 +2704,12 @@
         "multiformats": "^9.4.7"
       }
     },
+    "node_modules/blockstore-core/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true
+    },
     "node_modules/blueimp-md5": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
@@ -3110,6 +2720,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3119,6 +2730,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -3131,12 +2743,6 @@
       "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
       "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==",
       "dev": true
-    },
-    "node_modules/browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "peer": true
     },
     "node_modules/buffer": {
       "version": "6.0.3",
@@ -3165,7 +2771,8 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "node_modules/builtins": {
       "version": "5.0.1",
@@ -3180,7 +2787,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -3302,15 +2908,30 @@
         "multiformats": "^9.5.4"
       }
     },
-    "node_modules/cardex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-1.0.0.tgz",
-      "integrity": "sha512-Xirpn7ZPeNEIZ7spEOH7+RnFdZP2yVGMGR0Sj3ON4eEoCFZjzsnFXCYszTk39wWekst3GLN1E/yb2vKATQTMMg==",
+    "node_modules/carbites/node_modules/@ipld/dag-pb": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "dev": true,
       "dependencies": {
-        "@ipld/car": "^4.1.5",
-        "multiformats": "^9.6.5",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/carbites/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true
+    },
+    "node_modules/cardex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-1.0.1.tgz",
+      "integrity": "sha512-qtEBmfCPU9alMle+ZEJuBCO9OOPQmgowRzYcumxX0mI9aU0/GEvI6riZF6P2ouT4JH6yM3aYbDaqcoVuV3UVQw==",
+      "dependencies": {
+        "@ipld/car": "^5.1.0",
+        "multiformats": "^11.0.2",
         "sade": "^1.8.1",
-        "uint8arrays": "^3.0.0",
+        "uint8arrays": "^4.0.3",
         "varint": "^6.0.0"
       },
       "bin": {
@@ -3330,17 +2951,17 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.5.tgz",
-      "integrity": "sha512-fLBv8wmqtlXqy1Yu+pHzevAIkW6k2K0ZtMujNzWphLsA34vzzg9BHn+5GmZqOJkSA9V7EMKsWrf6K976c1QMjQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
+      "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ==",
       "bin": {
         "cborg": "cli.js"
       }
     },
     "node_modules/chalk": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -3358,6 +2979,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3387,10 +3009,19 @@
       "dev": true
     },
     "node_modules/ci-info": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
-      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
-      "dev": true
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ci-parallel-vars": {
       "version": "1.0.1",
@@ -3502,20 +3133,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/clone-regexp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
-      "integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
-      "dependencies": {
-        "is-regexp": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/code-excerpt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
@@ -3552,7 +3169,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/concordance": {
       "version": "5.0.4",
@@ -3574,32 +3192,30 @@
       }
     },
     "node_modules/conf": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
-      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-11.0.1.tgz",
+      "integrity": "sha512-WlLiQboEjKx0bYx2IIRGedBgNjLAxtwPaCSnsjWPST5xR0DB4q8lcsO/bEH9ZRYNcj63Y9vj/JG/5Fg6uWzI0Q==",
       "dependencies": {
-        "ajv": "^8.6.3",
+        "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
-        "atomically": "^1.7.0",
-        "debounce-fn": "^4.0.0",
-        "dot-prop": "^6.0.1",
-        "env-paths": "^2.2.1",
-        "json-schema-typed": "^7.0.3",
-        "onetime": "^5.1.2",
-        "pkg-up": "^3.1.0",
-        "semver": "^7.3.5"
+        "atomically": "^2.0.0",
+        "debounce-fn": "^5.1.2",
+        "dot-prop": "^7.2.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/conf/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -3615,39 +3231,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/conf/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/conf/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/convert-hrtime": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
-      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
@@ -3666,11 +3249,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cron-schedule": {
       "version": "3.0.6",
@@ -3704,28 +3282,31 @@
       }
     },
     "node_modules/dagula": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-4.1.1.tgz",
-      "integrity": "sha512-sBkyCB7z9wacSiXoP9Gmn7cfovTKenlK0Z8W3pSzS+S+EMfkwSwTrPcAHtnY6EqY4OCi2WTu74PZa9vXEl5WDw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/dagula/-/dagula-5.0.0.tgz",
+      "integrity": "sha512-cGlHQuIiNNyxP/ehMFuKCw59FMn+1zC+ESGmMuHc552bIIxLChfNwghY0bRGe0JyyS2pCi/5E+QcDTEfpxcxbw==",
       "dependencies": {
-        "@chainsafe/libp2p-noise": "^7.0.1",
-        "@ipld/car": "^4.1.3",
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-json": "^8.0.10",
-        "@ipld/dag-pb": "^2.1.17",
-        "@libp2p/interfaces": "^2.0.4",
-        "@libp2p/mplex": "^1.2.1",
-        "@libp2p/tcp": "^3.0.2",
-        "@libp2p/websockets": "^3.0.1",
-        "@multiformats/multiaddr": "^10.3.3",
-        "@web3-storage/fast-unixfs-exporter": "^0.2.1",
+        "@chainsafe/libp2p-noise": "^11.0.0",
+        "@ipld/car": "^5.0.3",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/interface-connection": "^3.0.8",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-registrar": "^2.0.8",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/mplex": "^7.1.1",
+        "@libp2p/tcp": "^6.0.9",
+        "@libp2p/websockets": "^5.0.3",
+        "@multiformats/multiaddr": "^11.3.0",
         "archy": "^1.0.0",
-        "conf": "^10.1.2",
+        "conf": "^11.0.1",
         "debug": "^4.3.4",
-        "it-length-prefixed": "^7.0.1",
+        "ipfs-unixfs-exporter": "^12.0.2",
+        "it-length-prefixed": "^8.0.4",
         "it-pipe": "^2.0.3",
-        "libp2p": "^0.37.3",
-        "multiformats": "^9.7.0",
+        "libp2p": "^0.42.2",
+        "multiformats": "^11.0.1",
         "p-defer": "^4.0.0",
         "protobufjs": "^7.0.0",
         "sade": "^1.8.1",
@@ -3750,11 +3331,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/dagula/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-    },
     "node_modules/dagula/node_modules/retimer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
@@ -3769,33 +3345,131 @@
       }
     },
     "node_modules/datastore-core": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-7.0.3.tgz",
-      "integrity": "sha512-DmPsUux63daOfCszxLkcp6LjdJ0k/BQNhIMtoAi5mbraYQnEQkFtKORmTu6XmDX6ujbtaBkeuJAiCBNI7MZklw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-8.0.4.tgz",
+      "integrity": "sha512-oBA6a024NFXJOTu+w9nLAimfy4wCYUhdE/5XQGtdKt1BmCVtPYW10GORvVT3pdZBcse6k/mVcBl+hjkXIlm65A==",
       "dependencies": {
-        "debug": "^4.1.1",
+        "@libp2p/logger": "^2.0.0",
         "err-code": "^3.0.1",
-        "interface-datastore": "^6.0.2",
-        "it-drain": "^1.0.4",
-        "it-filter": "^1.0.2",
-        "it-map": "^1.0.5",
-        "it-merge": "^1.0.1",
-        "it-pipe": "^1.1.0",
-        "it-pushable": "^1.4.2",
-        "it-take": "^1.0.1",
-        "uint8arrays": "^3.0.0"
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-drain": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-merge": "^2.0.0",
+        "it-pipe": "^2.0.3",
+        "it-pushable": "^3.0.0",
+        "it-take": "^2.0.0",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/datastore-core/node_modules/it-pushable": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-1.4.2.tgz",
-      "integrity": "sha512-vVPu0CGRsTI8eCfhMknA7KIBqqGFolbRx+1mbQ6XuZ7YCz995Qj7L4XUviwClFunisDq96FdxzF5FnAbw15afg==",
+    "node_modules/datastore-core/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
       "dependencies": {
-        "fast-fifo": "^1.0.0"
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/it-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/it-drain": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.1.tgz",
+      "integrity": "sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/it-filter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+      "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/it-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+      "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/it-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+      "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
+      "dependencies": {
+        "it-pushable": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/it-pipe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
+      "dependencies": {
+        "it-merge": "^2.0.0",
+        "it-pushable": "^3.1.0",
+        "it-stream-types": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/it-take": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.1.tgz",
+      "integrity": "sha512-DL7kpZNjuoeSTnB9dMAJ0Z3m2T29LRRAU+HIgkiQM+1jH3m8l9e/1xpWs8JHTlbKivbqSFrQMTc8KVcaQNmsaA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/nanoid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+      "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww==",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/date-time": {
@@ -3811,25 +3485,17 @@
       }
     },
     "node_modules/debounce-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
-      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-5.1.2.tgz",
+      "integrity": "sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==",
       "dependencies": {
-        "mimic-fn": "^3.0.0"
+        "mimic-fn": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/debounce-fn/node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/debug": {
@@ -4000,100 +3666,37 @@
       }
     },
     "node_modules/del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-7.0.0.tgz",
+      "integrity": "sha512-tQbV/4u5WVB8HMJr08pgw0b6nG4RGt/tj+7Numvq+zqcvUFeMaIWWOUFltiU+6go8BSO2/ogsB4EasDaj0y68Q==",
       "dev": true,
       "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
+        "globby": "^13.1.2",
+        "graceful-fs": "^4.2.10",
+        "is-glob": "^4.0.3",
+        "is-path-cwd": "^3.0.0",
+        "is-path-inside": "^4.0.0",
+        "p-map": "^5.5.0",
         "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
+        "slash": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/del/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/del/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/del/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/indent-string": {
+    "node_modules/del/node_modules/slash": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
       "dev": true,
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/del/node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -4132,14 +3735,25 @@
       }
     },
     "node_modules/dot-prop": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-7.2.0.tgz",
+      "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
       "dependencies": {
-        "is-obj": "^2.0.0"
+        "type-fest": "^2.11.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4173,12 +3787,12 @@
       }
     },
     "node_modules/emittery": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.11.0.tgz",
-      "integrity": "sha512-S/7tzL6v5i+4iJd627Nhv9cLFIo5weAIlGccqJFpnBoDB8U1TF2k5tez4J/QNuxyyhWuFqHg1L84Kd3m7iXg6g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.1.tgz",
+      "integrity": "sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
@@ -4200,11 +3814,14 @@
       }
     },
     "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/err-code": {
@@ -4286,9 +3903,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.10.tgz",
-      "integrity": "sha512-N7wBhfJ/E5fzn/SpNgX+oW2RLRjwaL8Y0ezqNqhjD6w0H2p0rDuEz2FKZqpqLnO8DCaWumKe8dsC/ljvVSSxng==",
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.11.tgz",
+      "integrity": "sha512-pAMImyokbWDtnA/ufPxjQg0fYo2DDuzAlqwnDvbXqHLphe+m80eF++perYKVm8LeTuj2zUuFXC+xgSVxyoHUdg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -4298,348 +3915,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.15.10",
-        "@esbuild/linux-loong64": "0.15.10",
-        "esbuild-android-64": "0.15.10",
-        "esbuild-android-arm64": "0.15.10",
-        "esbuild-darwin-64": "0.15.10",
-        "esbuild-darwin-arm64": "0.15.10",
-        "esbuild-freebsd-64": "0.15.10",
-        "esbuild-freebsd-arm64": "0.15.10",
-        "esbuild-linux-32": "0.15.10",
-        "esbuild-linux-64": "0.15.10",
-        "esbuild-linux-arm": "0.15.10",
-        "esbuild-linux-arm64": "0.15.10",
-        "esbuild-linux-mips64le": "0.15.10",
-        "esbuild-linux-ppc64le": "0.15.10",
-        "esbuild-linux-riscv64": "0.15.10",
-        "esbuild-linux-s390x": "0.15.10",
-        "esbuild-netbsd-64": "0.15.10",
-        "esbuild-openbsd-64": "0.15.10",
-        "esbuild-sunos-64": "0.15.10",
-        "esbuild-windows-32": "0.15.10",
-        "esbuild-windows-64": "0.15.10",
-        "esbuild-windows-arm64": "0.15.10"
-      }
-    },
-    "node_modules/esbuild-android-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.10.tgz",
-      "integrity": "sha512-UI7krF8OYO1N7JYTgLT9ML5j4+45ra3amLZKx7LO3lmLt1Ibn8t3aZbX5Pu4BjWiqDuJ3m/hsvhPhK/5Y/YpnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-android-arm64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.10.tgz",
-      "integrity": "sha512-EOt55D6xBk5O05AK8brXUbZmoFj4chM8u3riGflLa6ziEoVvNjRdD7Cnp82NHQGfSHgYR06XsPI8/sMuA/cUwg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-darwin-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.10.tgz",
-      "integrity": "sha512-hbDJugTicqIm+WKZgp208d7FcXcaK8j2c0l+fqSJ3d2AzQAfjEYDRM3Z2oMeqSJ9uFxyj/muSACLdix7oTstRA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.10.tgz",
-      "integrity": "sha512-M1t5+Kj4IgSbYmunf2BB6EKLkWUq+XlqaFRiGOk8bmBapu9bCDrxjf4kUnWn59Dka3I27EiuHBKd1rSO4osLFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-freebsd-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.10.tgz",
-      "integrity": "sha512-KMBFMa7C8oc97nqDdoZwtDBX7gfpolkk6Bcmj6YFMrtCMVgoU/x2DI1p74DmYl7CSS6Ppa3xgemrLrr5IjIn0w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.10.tgz",
-      "integrity": "sha512-m2KNbuCX13yQqLlbSojFMHpewbn8wW5uDS6DxRpmaZKzyq8Dbsku6hHvh2U+BcLwWY4mpgXzFUoENEf7IcioGg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-32": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.10.tgz",
-      "integrity": "sha512-guXrwSYFAvNkuQ39FNeV4sNkNms1bLlA5vF1H0cazZBOLdLFIny6BhT+TUbK/hdByMQhtWQ5jI9VAmPKbVPu1w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.10.tgz",
-      "integrity": "sha512-jd8XfaSJeucMpD63YNMO1JCrdJhckHWcMv6O233bL4l6ogQKQOxBYSRP/XLWP+6kVTu0obXovuckJDcA0DKtQA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-arm": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.10.tgz",
-      "integrity": "sha512-6N8vThLL/Lysy9y4Ex8XoLQAlbZKUyExCWyayGi2KgTBelKpPgj6RZnUaKri0dHNPGgReJriKVU6+KDGQwn10A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-arm64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.10.tgz",
-      "integrity": "sha512-GByBi4fgkvZFTHFDYNftu1DQ1GzR23jws0oWyCfhnI7eMOe+wgwWrc78dbNk709Ivdr/evefm2PJiUBMiusS1A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-mips64le": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.10.tgz",
-      "integrity": "sha512-BxP+LbaGVGIdQNJUNF7qpYjEGWb0YyHVSKqYKrn+pTwH/SiHUxFyJYSP3pqkku61olQiSBnSmWZ+YUpj78Tw7Q==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.10.tgz",
-      "integrity": "sha512-LoSQCd6498PmninNgqd/BR7z3Bsk/mabImBWuQ4wQgmQEeanzWd5BQU2aNi9mBURCLgyheuZS6Xhrw5luw3OkQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-riscv64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.10.tgz",
-      "integrity": "sha512-Lrl9Cr2YROvPV4wmZ1/g48httE8z/5SCiXIyebiB5N8VT7pX3t6meI7TQVHw/wQpqP/AF4SksDuFImPTM7Z32Q==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-s390x": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.10.tgz",
-      "integrity": "sha512-ReP+6q3eLVVP2lpRrvl5EodKX7EZ1bS1/z5j6hsluAlZP5aHhk6ghT6Cq3IANvvDdscMMCB4QEbI+AjtvoOFpA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-netbsd-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.10.tgz",
-      "integrity": "sha512-iGDYtJCMCqldMskQ4eIV+QSS/CuT7xyy9i2/FjpKvxAuCzrESZXiA1L64YNj6/afuzfBe9i8m/uDkFHy257hTw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-openbsd-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.10.tgz",
-      "integrity": "sha512-ftMMIwHWrnrYnvuJQRJs/Smlcb28F9ICGde/P3FUTCgDDM0N7WA0o9uOR38f5Xe2/OhNCgkjNeb7QeaE3cyWkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-sunos-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.10.tgz",
-      "integrity": "sha512-mf7hBL9Uo2gcy2r3rUFMjVpTaGpFJJE5QTDDqUFf1632FxteYANffDZmKbqX0PfeQ2XjUDE604IcE7OJeoHiyg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-32": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.10.tgz",
-      "integrity": "sha512-ttFVo+Cg8b5+qHmZHbEc8Vl17kCleHhLzgT8X04y8zudEApo0PxPg9Mz8Z2cKH1bCYlve1XL8LkyXGFjtUYeGg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.10.tgz",
-      "integrity": "sha512-2H0gdsyHi5x+8lbng3hLbxDWR7mKHWh5BXZGKVG830KUmXOOWFE2YKJ4tHRkejRduOGDrBvHBriYsGtmTv3ntA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-arm64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.10.tgz",
-      "integrity": "sha512-S+th4F+F8VLsHLR0zrUcG+Et4hx0RKgK1eyHc08kztmLOES8BWwMiaGdoW9hiXuzznXQ0I/Fg904MNbr11Nktw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
+        "@esbuild/android-arm": "0.17.11",
+        "@esbuild/android-arm64": "0.17.11",
+        "@esbuild/android-x64": "0.17.11",
+        "@esbuild/darwin-arm64": "0.17.11",
+        "@esbuild/darwin-x64": "0.17.11",
+        "@esbuild/freebsd-arm64": "0.17.11",
+        "@esbuild/freebsd-x64": "0.17.11",
+        "@esbuild/linux-arm": "0.17.11",
+        "@esbuild/linux-arm64": "0.17.11",
+        "@esbuild/linux-ia32": "0.17.11",
+        "@esbuild/linux-loong64": "0.17.11",
+        "@esbuild/linux-mips64el": "0.17.11",
+        "@esbuild/linux-ppc64": "0.17.11",
+        "@esbuild/linux-riscv64": "0.17.11",
+        "@esbuild/linux-s390x": "0.17.11",
+        "@esbuild/linux-x64": "0.17.11",
+        "@esbuild/netbsd-x64": "0.17.11",
+        "@esbuild/openbsd-x64": "0.17.11",
+        "@esbuild/sunos-x64": "0.17.11",
+        "@esbuild/win32-arm64": "0.17.11",
+        "@esbuild/win32-ia32": "0.17.11",
+        "@esbuild/win32-x64": "0.17.11"
       }
     },
     "node_modules/escalade": {
@@ -5446,16 +4743,16 @@
       }
     },
     "node_modules/figures": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-4.0.1.tgz",
-      "integrity": "sha512-rElJwkA/xS04Vfg+CaZodpso7VqBknOYbzi6I76hI4X80RUjkSxO2oAyPmGbuXUppywjqndOrQDl817hDnI++w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^5.0.0",
         "is-unicode-supported": "^1.2.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5499,6 +4796,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -5529,15 +4827,6 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "peer": true,
-      "bin": {
-        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -5580,12 +4869,14 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -5600,17 +4891,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "node_modules/function-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
-      "integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -5729,6 +5009,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -5764,9 +5045,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
-      "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
       "dev": true,
       "dependencies": {
         "dir-glob": "^3.0.1",
@@ -5806,13 +5087,17 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "peer": true,
+    "node_modules/hamt-sharding": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.2.tgz",
+      "integrity": "sha512-f0DzBD2tSmLFdFsLAvOflIBqFPjerbA7BfmwO8mVho/5hXwgyyYhv+ijIzidQf/DpDX3bRjAQvhGoBFj+DBvPw==",
+      "dependencies": {
+        "sparse-array": "^1.3.1",
+        "uint8arrays": "^4.0.2"
+      },
       "engines": {
-        "node": ">=4.x"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/hard-rejection": {
@@ -5898,15 +5183,6 @@
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
       "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "peer": true,
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -5926,9 +5202,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/human-signals": {
@@ -6049,6 +5325,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6057,31 +5334,56 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/interface-blockstore": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.3.tgz",
       "integrity": "sha512-OwVUnlNcx7H5HloK0Myv6c/C1q9cNG11HX6afdeU6q6kbuNj8jKCwVnmJHhC94LZaJ+9hvVOk4IUstb3Esg81w==",
+      "dev": true,
       "dependencies": {
         "interface-store": "^2.0.2",
         "multiformats": "^9.0.4"
       }
     },
+    "node_modules/interface-blockstore/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true
+    },
     "node_modules/interface-datastore": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
       "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "dev": true,
       "dependencies": {
         "interface-store": "^2.0.2",
         "nanoid": "^3.0.2",
         "uint8arrays": "^3.0.0"
       }
     },
+    "node_modules/interface-datastore/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/interface-store": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
-      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg==",
+      "dev": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -6101,6 +5403,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
       "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6114,9 +5417,9 @@
       }
     },
     "node_modules/ipfs-car": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.8.1.tgz",
-      "integrity": "sha512-ntRXBK5ZTaXgxAkSLvC6mXupJcwxxX9tusKoOJR+SRZWGfA+5j+WeJa5gCgdHEsGixIX93rZH8DSzdUUTYjNJg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.9.2.tgz",
+      "integrity": "sha512-OUKgQqCN9C16eyu9OSOXe2CyRUL/jemWDODfALihvwRHfLLU6tKQVb8rhjhheWhQ1InlFBMgfIiLNxGpUSqOXA==",
       "dev": true,
       "dependencies": {
         "@ipld/car": "^3.2.3",
@@ -6157,6 +5460,25 @@
         "varint": "^6.0.0"
       }
     },
+    "node_modules/ipfs-car/node_modules/@ipld/dag-cbor": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "dev": true,
+      "dependencies": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/@ipld/dag-pb": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^9.5.4"
+      }
+    },
     "node_modules/ipfs-car/node_modules/hamt-sharding": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
@@ -6193,6 +5515,12 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/ipfs-car/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true
+    },
     "node_modules/ipfs-car/node_modules/streaming-iterables": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.2.0.tgz",
@@ -6200,6 +5528,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/ipfs-core-types": {
@@ -6212,6 +5549,12 @@
         "multiaddr": "^10.0.0",
         "multiformats": "^9.4.13"
       }
+    },
+    "node_modules/ipfs-core-types/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true
     },
     "node_modules/ipfs-core-utils": {
       "version": "0.12.2",
@@ -6241,10 +5584,26 @@
         "uint8arrays": "^3.0.0"
       }
     },
+    "node_modules/ipfs-core-utils/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true
+    },
+    "node_modules/ipfs-core-utils/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/ipfs-unixfs": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
       "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+      "dev": true,
       "dependencies": {
         "err-code": "^3.0.1",
         "protobufjs": "^6.10.2"
@@ -6252,6 +5611,151 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-12.0.2.tgz",
+      "integrity": "sha512-bt93YHQplKWFPqZCsAZLBbHG11dNuJtyvnZakcKmbYUC8iPyy0dfHPcTEB8Rz6JL7lSAJp7M4g4dCdv2U6sBGw==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@multiformats/murmur3": "^2.0.0",
+        "err-code": "^3.0.1",
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^4.0.1",
+        "ipfs-unixfs": "^11.0.0",
+        "it-filter": "^2.0.0",
+        "it-last": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^2.0.4",
+        "it-pushable": "^3.1.0",
+        "multiformats": "^11.0.0",
+        "p-queue": "^7.3.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/@multiformats/murmur3": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.3.tgz",
+      "integrity": "sha512-YvLK1IrLnRckPsvXhOkZjaIGNonsEdD1dL3NPSaLilV/WjVYeBgnNZXTUsaPzFXGrIFM7motx+yCmmqzXO6gtQ==",
+      "dependencies": {
+        "multiformats": "^11.0.0",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/interface-blockstore": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-4.0.1.tgz",
+      "integrity": "sha512-ROWKGJls7vLeFaQtI3hZVCJOkUoZ05xAi2t2qysM4d7dwVKrfm5jUOqWh8JgLL7Iup3XqJ0mKXXZuwJ3s03RSw==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/ipfs-unixfs": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.0.tgz",
+      "integrity": "sha512-ZHTTzP5yuimLTln+8VKc3IcsO4ObS6/U8eZ3CA69s1DdW9uBfyjEo6/GTZA80yokHVGWvmCl1S28zmJ5JskP4Q==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/it-filter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+      "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/it-last": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.1.tgz",
+      "integrity": "sha512-uVMedYW0wa2Cx0TAmcOCLbfuLLII7+vyURmhKa8Zovpd+aBTMsmINtsta2n364wJ5qsEDBH+akY1sUtAkaYBlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/it-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+      "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/it-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+      "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
+      "dependencies": {
+        "it-pushable": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/it-pipe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
+      "dependencies": {
+        "it-merge": "^2.0.0",
+        "it-pushable": "^3.1.0",
+        "it-stream-types": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/protons-runtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+      "dependencies": {
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/ipfs-unixfs-importer": {
@@ -6281,6 +5785,15 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/ipfs-unixfs-importer/node_modules/@ipld/dag-pb": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^9.5.4"
+      }
+    },
     "node_modules/ipfs-unixfs-importer/node_modules/hamt-sharding": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
@@ -6295,15 +5808,32 @@
         "npm": ">=6.0.0"
       }
     },
+    "node_modules/ipfs-unixfs-importer/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true
+    },
+    "node_modules/ipfs-unixfs-importer/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/ipfs-unixfs/node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "node_modules/ipfs-unixfs/node_modules/protobufjs": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
       "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -6400,6 +5930,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -6477,6 +6008,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6512,6 +6044,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6523,6 +6056,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
       "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dev": true,
       "dependencies": {
         "ip-regex": "^4.0.0"
       },
@@ -6551,6 +6085,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6570,30 +6105,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
+      "integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -6633,17 +6166,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-regexp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-shared-array-buffer": {
@@ -6748,18 +6270,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "node_modules/iso-random-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.2.tgz",
-      "integrity": "sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==",
-      "dependencies": {
-        "events": "^3.3.0",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/iso-url": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
@@ -6771,7 +6281,8 @@
     "node_modules/it-all": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+      "dev": true
     },
     "node_modules/it-batch": {
       "version": "1.0.9",
@@ -6779,15 +6290,31 @@
       "integrity": "sha512-7Q7HXewMhNFltTsAMdSz6luNhyhkhEtGGbYek/8Xb/GiqYMtwUmopE1ocPSiJKKp3rM4Dt045sNFoUu+KZGNyA==",
       "dev": true
     },
+    "node_modules/it-batched-bytes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-1.0.1.tgz",
+      "integrity": "sha512-ptBiZ0Mh3kJYySpG0pCS7JgvWhaAW1fGfKDVFtNIuNTA+bpSlXINvD5H3b14ZlJbnJFzFzRSCSZ10E1nH4z/WQ==",
+      "dependencies": {
+        "it-stream-types": "^1.0.4",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/it-drain": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.5.tgz",
-      "integrity": "sha512-r/GjkiW1bZswC04TNmUnLxa6uovme7KKwPhc+cb1hHU65E3AByypHH6Pm91WHuvqfFsm+9ws0kPtDBV3/8vmIg=="
+      "integrity": "sha512-r/GjkiW1bZswC04TNmUnLxa6uovme7KKwPhc+cb1hHU65E3AByypHH6Pm91WHuvqfFsm+9ws0kPtDBV3/8vmIg==",
+      "dev": true
     },
     "node_modules/it-filter": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.3.tgz",
-      "integrity": "sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w=="
+      "integrity": "sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w==",
+      "dev": true
     },
     "node_modules/it-first": {
       "version": "1.0.7",
@@ -6795,9 +6322,13 @@
       "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
     },
     "node_modules/it-foreach": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-0.1.1.tgz",
-      "integrity": "sha512-ZLxL651N5w5SL/EIIcrXELgYrrkuEKj/TErG93C4lr6lNZziKsf338ljSG85PjQfu7Frg/1wESl5pLrPSFXI9g=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-1.0.1.tgz",
+      "integrity": "sha512-eaVFhKxU+uwPs7+DKYxjuL6pj6c50/MBlAH+XPMgPWRRVIChVoyEIsdUQkkC0Ad6oTUmJbKRTnJxEY6o2aIs7A==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-glob": {
       "version": "1.0.2",
@@ -6825,37 +6356,22 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/it-handshake/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-    },
     "node_modules/it-last": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
-      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q==",
+      "dev": true
     },
     "node_modules/it-length-prefixed": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-7.0.1.tgz",
-      "integrity": "sha512-UozKoT0zZPUa0LO9OSq5KaLKPn83U7Vsy/BNAN0TUXfTI/pKrOz6RuyTSOok6NDad12FZsShBGnl9DKlfDT95g==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.4.tgz",
+      "integrity": "sha512-5OJ1lxH+IaqJB7lxe8IAIwt9UfSfsmjKJoAI/RO9djYoBDt1Jfy9PeVHUmOfqhqyu/4kJvWBFAJUaG1HhLQ12A==",
       "dependencies": {
         "err-code": "^3.0.1",
         "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.2.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-length-prefixed/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
+        "uint8-varint": "^1.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -6865,7 +6381,8 @@
     "node_modules/it-map": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
-      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ==",
+      "dev": true
     },
     "node_modules/it-merge": {
       "version": "1.0.4",
@@ -6884,11 +6401,23 @@
       }
     },
     "node_modules/it-pair": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.3.tgz",
-      "integrity": "sha512-heCgsbYscFCQY5YvltlGT9tjgLGYo7NxPEoJyl55X4BD2KOXpTyuwOhPLWhi9Io0y6+4ZUXCkyaQXIB6Y8xhRw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.4.tgz",
+      "integrity": "sha512-S3y3mTJ3muuxcHBGcIzNONofAN+G3iAgmSjS78qARkRWI2ImJXybjj0h52uSW+isgrJqIx2iFB/T8ZEBc8kDSw==",
       "dependencies": {
         "it-stream-types": "^1.0.3",
+        "p-defer": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-parallel": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.1.tgz",
+      "integrity": "sha512-Wq9DcoLrFV9n5YzWC4BlOQT+v5qgir/iIO/CJ1eV0T5t9rcCZFPKOZB3E8wIhZ5ruSApc2w7UKrbn5iENqew5A==",
+      "dependencies": {
         "p-defer": "^4.0.0"
       },
       "engines": {
@@ -6906,30 +6435,14 @@
       }
     },
     "node_modules/it-pb-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-2.0.2.tgz",
-      "integrity": "sha512-FR1FM9W71wMTZlAij1Pq4PKNcfVb0TGhUTpNQ3tv0LMV/pJ5cDh4g3jW7jhwB+kHtr7PywD1CybBHaT8iAVpKg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-2.0.4.tgz",
+      "integrity": "sha512-p0chBIT3HrZt3hIqvBEi+NgZxxT25MTJ362nKoHmzA/k/WsUPPbeSz7Ad+wRcGxZn2O5JEXCS5lOGRjSDSnlNg==",
       "dependencies": {
         "it-handshake": "^4.1.2",
         "it-length-prefixed": "^8.0.2",
         "it-stream-types": "^1.0.4",
         "uint8arraylist": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-pb-stream/node_modules/it-length-prefixed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-      "integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-      "dependencies": {
-        "err-code": "^3.0.1",
-        "it-stream-types": "^1.0.4",
-        "uint8-varint": "^1.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -6945,17 +6458,22 @@
     "node_modules/it-pipe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
-      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg==",
+      "dev": true
     },
     "node_modules/it-pushable": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-2.0.2.tgz",
-      "integrity": "sha512-f/n6HqXGDbHvuMR/3UN+S6W4y/bS1Pxg6Lb0oVc5dbflxy5f3NKkizKs86B8vzqHnB9hm1YpE0pgcEvI3FKDQw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
+      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-reader": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.1.tgz",
-      "integrity": "sha512-C+YRk3OTufbKSJMNEonfEw+9F38llmwwZvqhkjb0xIgob7l4L3p01Yt43+bHRI8SSppAOgk5AKLqas7ea0UTAw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.2.tgz",
+      "integrity": "sha512-rQdVyml+r/2v8PQsPfJgf626tAkbA7NW1EF6zuucT2Ryy1U6YJtSuCJL8fKuDOyiR/mLzbfP0QQJlSeeoLph2A==",
       "dependencies": {
         "it-stream-types": "^1.0.4",
         "uint8arraylist": "^2.0.0"
@@ -6966,11 +6484,24 @@
       }
     },
     "node_modules/it-sort": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-1.0.1.tgz",
-      "integrity": "sha512-c+C48cP7XMMebB9irLrJs2EmpLILId8NYSojqAqN8etE8ienx0azBgaKvZHYH1DkerqIul0Fl2FqISu2BZgTEQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-2.0.1.tgz",
+      "integrity": "sha512-9f4jKOTHfxc/FJpg/wwuQ+j+88i+sfNGKsu2HukAKymm71/XDnBFtOAOzaimko3YIhmn/ERwnfEKrsYLykxw9A==",
       "dependencies": {
-        "it-all": "^1.0.6"
+        "it-all": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-sort/node_modules/it-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/it-stream-types": {
@@ -6981,7 +6512,8 @@
     "node_modules/it-take": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.2.tgz",
-      "integrity": "sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw=="
+      "integrity": "sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw==",
+      "dev": true
     },
     "node_modules/it-to-stream": {
       "version": "1.0.0",
@@ -7007,14 +6539,14 @@
       }
     },
     "node_modules/it-ws": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.2.tgz",
-      "integrity": "sha512-beq/nBWuKm2Ds4nYSfPuZRF0USVZJhsIvuUH3kRE5QdaCzivDK7zyeewDgsNBSPr6hPgF5dyPP5NXcXhUcb9QQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.6.tgz",
+      "integrity": "sha512-TEEJQaGtkxgP/nGVq8dq48nPT85Afu8kwwvtDFLj4rQLWRhZcb26RWdXLdn9qhXkWPiWbK5H7JWBW1Bebj/SuQ==",
       "dependencies": {
         "event-iterator": "^2.0.0",
         "iso-url": "^1.1.2",
         "it-stream-types": "^1.0.2",
-        "uint8arrays": "^3.0.0",
+        "uint8arrays": "^4.0.2",
         "ws": "^8.4.0"
       },
       "engines": {
@@ -7047,6 +6579,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -7078,9 +6611,9 @@
       "dev": true
     },
     "node_modules/json-schema-typed": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
-      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.1.tgz",
+      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -7092,7 +6625,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -7145,130 +6678,78 @@
       }
     },
     "node_modules/libp2p": {
-      "version": "0.37.3",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.37.3.tgz",
-      "integrity": "sha512-G+0tWT6jZr05XE9bG8Kw1SqFrkt1X3bM9TDDXkqWqHvUVjBHWGNDysOvTp7p3jxoSj4J/Z2w9wGbdDsz1kfPlw==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.42.2.tgz",
+      "integrity": "sha512-arTOCJEEmAFw5HjlXdULVAFs7Y/dWZmgX/qN4SzuxtSkB0pa+fqn/DIbIfpBi2BuY+QozvnARPF1xJtSdqfqJQ==",
       "dependencies": {
         "@achingbrain/nat-port-mapper": "^1.0.3",
-        "@libp2p/connection": "^2.0.2",
-        "@libp2p/crypto": "^0.22.11",
-        "@libp2p/interfaces": "^2.0.2",
-        "@libp2p/logger": "^1.1.4",
-        "@libp2p/multistream-select": "^1.0.4",
-        "@libp2p/peer-collections": "^1.0.2",
-        "@libp2p/peer-id": "^1.1.10",
-        "@libp2p/peer-id-factory": "^1.0.9",
-        "@libp2p/peer-record": "^1.0.8",
-        "@libp2p/peer-store": "^1.0.10",
-        "@libp2p/tracked-map": "^1.0.5",
-        "@libp2p/utils": "^1.0.10",
+        "@libp2p/crypto": "^1.0.4",
+        "@libp2p/interface-address-manager": "^2.0.0",
+        "@libp2p/interface-connection": "^3.0.2",
+        "@libp2p/interface-connection-encrypter": "^3.0.1",
+        "@libp2p/interface-connection-manager": "^1.1.1",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interface-libp2p": "^1.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-discovery": "^1.0.1",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-routing": "^1.0.1",
+        "@libp2p/interface-peer-store": "^1.2.2",
+        "@libp2p/interface-pubsub": "^3.0.0",
+        "@libp2p/interface-registrar": "^2.0.3",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interface-transport": "^2.1.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.1",
+        "@libp2p/multistream-select": "^3.0.0",
+        "@libp2p/peer-collections": "^3.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-id-factory": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@libp2p/peer-store": "^6.0.0",
+        "@libp2p/tracked-map": "^3.0.0",
+        "@libp2p/utils": "^3.0.2",
         "@multiformats/mafmt": "^11.0.2",
-        "@multiformats/multiaddr": "^10.1.8",
+        "@multiformats/multiaddr": "^11.0.0",
         "abortable-iterator": "^4.0.2",
         "any-signal": "^3.0.0",
-        "datastore-core": "^7.0.0",
+        "datastore-core": "^8.0.1",
         "err-code": "^3.0.1",
         "events": "^3.3.0",
         "hashlru": "^2.3.0",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-drain": "^1.0.5",
-        "it-filter": "^1.0.3",
-        "it-first": "^1.0.6",
-        "it-foreach": "^0.1.1",
-        "it-handshake": "^3.0.1",
-        "it-length-prefixed": "^7.0.1",
-        "it-map": "^1.0.6",
-        "it-merge": "^1.0.3",
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-drain": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-first": "^2.0.0",
+        "it-foreach": "^1.0.0",
+        "it-handshake": "^4.1.2",
+        "it-length-prefixed": "^8.0.2",
+        "it-map": "^2.0.0",
+        "it-merge": "^2.0.0",
         "it-pair": "^2.0.2",
         "it-pipe": "^2.0.3",
-        "it-sort": "^1.0.1",
+        "it-sort": "^2.0.0",
         "it-stream-types": "^1.0.4",
         "merge-options": "^3.0.4",
-        "multiformats": "^9.6.3",
-        "mutable-proxy": "^1.0.0",
-        "node-forge": "^1.2.1",
+        "multiformats": "^11.0.0",
+        "node-forge": "^1.3.1",
         "p-fifo": "^1.0.0",
         "p-retry": "^5.0.0",
         "p-settle": "^5.0.0",
-        "private-ip": "^2.3.3",
-        "protons-runtime": "^1.0.4",
+        "private-ip": "^3.0.0",
+        "protons-runtime": "^4.0.1",
+        "rate-limiter-flexible": "^2.3.11",
         "retimer": "^3.0.0",
         "sanitize-filename": "^1.6.3",
         "set-delayed-interval": "^1.0.0",
         "timeout-abort-controller": "^3.0.0",
-        "uint8arrays": "^3.0.0",
-        "wherearewe": "^1.0.0",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2",
+        "wherearewe": "^2.0.0",
         "xsalsa20": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/crypto": {
-      "version": "0.22.14",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-0.22.14.tgz",
-      "integrity": "sha512-5RyGh5ovfqrDD8Io3n5rvVnsTHBf1exIMZ/5eBw7Eoy21xkmzdF1Hy701SoSNmiCuTPXYmxT5WMy2VUDBUG6oQ==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.1",
-        "@noble/ed25519": "^1.6.0",
-        "@noble/secp256k1": "^1.5.4",
-        "err-code": "^3.0.1",
-        "iso-random-stream": "^2.0.0",
-        "multiformats": "^9.4.5",
-        "node-forge": "^1.1.0",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/peer-collections": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-1.0.3.tgz",
-      "integrity": "sha512-xrnFlZ2CpYiUQ0fGE0WqfBONiE2rjkjWHXnS6gH7CudlD0JMSftbzI+naBXRunfZal7CNEtHN7+keVX+ingPgA==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/peer-id": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/utils": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-1.0.10.tgz",
-      "integrity": "sha512-jlVLfac1IoBlgXL8V+XZYxNw0SOAkKweiLhXWolUbKOgRtMDquJzbwG1n8y9GtdiFKPlkiBwOB7l9xighcOR6w==",
-      "dependencies": {
-        "@achingbrain/ip-address": "^8.1.0",
-        "@libp2p/logger": "^1.0.1",
-        "@multiformats/multiaddr": "^10.1.1",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "is-loopback-addr": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
-        "ts-mocha": "^9.0.2",
-        "ts-node": "^10.7.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -7280,16 +6761,80 @@
       "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
       "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
     },
-    "node_modules/libp2p/node_modules/it-handshake": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-3.0.1.tgz",
-      "integrity": "sha512-Rx9ESanlfnC0aMw2LtLJ9YNlCNgnZU7wOHPzPSZTUAjbdZx54kllGR5ndIuoJqF2EtNIsmTiWEncKTgwHNJSSg==",
+    "node_modules/libp2p/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
       "dependencies": {
-        "it-map": "^1.0.6",
-        "it-pushable": "^2.0.1",
-        "it-reader": "^5.0.0",
-        "it-stream-types": "^1.0.4",
-        "p-defer": "^4.0.0"
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/it-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/it-drain": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.1.tgz",
+      "integrity": "sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/it-filter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+      "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/it-first": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
+      "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/it-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+      "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/it-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+      "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
+      "dependencies": {
+        "it-pushable": "^3.1.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -7297,11 +6842,11 @@
       }
     },
     "node_modules/libp2p/node_modules/it-pipe": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-      "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
       "dependencies": {
-        "it-merge": "^1.0.4",
+        "it-merge": "^2.0.0",
         "it-pushable": "^3.1.0",
         "it-stream-types": "^1.0.3"
       },
@@ -7310,35 +6855,15 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/libp2p/node_modules/it-pipe/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-    },
-    "node_modules/libp2p/node_modules/it-reader": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-5.0.2.tgz",
-      "integrity": "sha512-OgcWA/ffAALrkuUN2sQsbKa3of5oOyLvlXJgSCZdn9sSLZ0rnNmtsJ3lP/WEfWJH8aUNs3bfG6ja3QXKcCOwFw==",
-      "dependencies": {
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.2.0"
+    "node_modules/libp2p/node_modules/nanoid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+      "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww==",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/protons-runtime": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-      "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-      "dependencies": {
-        "uint8arraylist": "^1.4.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/libp2p/node_modules/retimer": {
@@ -7352,30 +6877,6 @@
       "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
       "dependencies": {
         "retimer": "^3.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/wherearewe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
-      "integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
-      "dependencies": {
-        "is-electron": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -7414,8 +6915,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -7423,108 +6923,10 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/log-symbols/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/log-symbols/node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/long": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/longbits": {
       "version": "1.1.0",
@@ -7566,11 +6968,6 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.12.tgz",
       "integrity": "sha512-Rkukya32FnY3dF5nJeAS4Qcry76tXeOe2sXIQGAt969sV04QLormWHXmHn4o/yIbb4wRlnCqWu8fpVg3TU7sFg=="
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
@@ -7716,7 +7113,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -7734,28 +7130,28 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.10.0.tgz",
-      "integrity": "sha512-WPveqChVDdmDGv+wFqXjFqEZlZ5/aBlAKX37h/e4TAjl2XsK5nPfQATP8jZXwNDEC5iE29bYZymOqeZkp+t7OA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.9.0.tgz",
+      "integrity": "sha512-HBGQ5Jj6sMU1B1hX6G3ML46ThtUvu1nvxgXjDDmhp2RhWKYj0XvcohW/nPPL/MTP1gpvfT880De9EHmobVsDsw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/cache": "2.10.0",
-        "@miniflare/cli-parser": "2.10.0",
-        "@miniflare/core": "2.10.0",
-        "@miniflare/d1": "2.10.0",
-        "@miniflare/durable-objects": "2.10.0",
-        "@miniflare/html-rewriter": "2.10.0",
-        "@miniflare/http-server": "2.10.0",
-        "@miniflare/kv": "2.10.0",
-        "@miniflare/queues": "2.10.0",
-        "@miniflare/r2": "2.10.0",
-        "@miniflare/runner-vm": "2.10.0",
-        "@miniflare/scheduler": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/sites": "2.10.0",
-        "@miniflare/storage-file": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0",
-        "@miniflare/web-sockets": "2.10.0",
+        "@miniflare/cache": "2.9.0",
+        "@miniflare/cli-parser": "2.9.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/d1": "2.9.0",
+        "@miniflare/durable-objects": "2.9.0",
+        "@miniflare/html-rewriter": "2.9.0",
+        "@miniflare/http-server": "2.9.0",
+        "@miniflare/kv": "2.9.0",
+        "@miniflare/queues": "2.9.0",
+        "@miniflare/r2": "2.9.0",
+        "@miniflare/runner-vm": "2.9.0",
+        "@miniflare/scheduler": "2.9.0",
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/sites": "2.9.0",
+        "@miniflare/storage-file": "2.9.0",
+        "@miniflare/storage-memory": "2.9.0",
+        "@miniflare/web-sockets": "2.9.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -7768,7 +7164,7 @@
         "node": ">=16.13"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.10.0",
+        "@miniflare/storage-redis": "2.9.0",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -7799,7 +7195,8 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -7833,336 +7230,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
-      "peer": true,
-      "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.3",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.1",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
-      }
-    },
-    "node_modules/mocha/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "peer": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "peer": true
-    },
-    "node_modules/mocha/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "peer": true
-    },
-    "node_modules/mocha/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mocha/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mocha/node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
-      "peer": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/mocha/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "peer": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "peer": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "peer": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mocha/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/mortice": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.1.tgz",
@@ -8179,9 +7246,9 @@
       }
     },
     "node_modules/mortice/node_modules/nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+      "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww==",
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -8190,9 +7257,9 @@
       }
     },
     "node_modules/mortice/node_modules/p-timeout": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
-      "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
+      "integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w==",
       "engines": {
         "node": ">=14.16"
       },
@@ -8259,10 +7326,29 @@
         "multiaddr": "^10.0.0"
       }
     },
-    "node_modules/multiformats": {
+    "node_modules/multiaddr/node_modules/multiformats": {
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true
+    },
+    "node_modules/multiaddr/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -8281,19 +7367,11 @@
         "mustache": "bin/mustache"
       }
     },
-    "node_modules/mutable-proxy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mutable-proxy/-/mutable-proxy-1.0.0.tgz",
-      "integrity": "sha512-4OvNRr1DJpy2QuDUV74m+BWZ//n4gG4bmd21MzDSPqHEidIDWqwyOjcadU1LBMO3vXYGurVKjfBrxrSQIHFu9A==",
-      "engines": {
-        "node": ">=6.X.X",
-        "npm": ">=3.X.X"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -8385,6 +7463,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8547,6 +7626,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8671,9 +7751,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
+      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
       "dependencies": {
         "eventemitter3": "^4.0.7",
         "p-timeout": "^5.0.2"
@@ -8697,9 +7777,9 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.1.tgz",
-      "integrity": "sha512-i69WkEU5ZAL8mrmdmVviWwU+DN+IUF8f4sSJThoJ3z5A7Nn5iuO5ROX3Boye0u+uYQLOSfgFl7SuFZCjlAVbQA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
       "dependencies": {
         "@types/retry": "0.12.1",
         "retry": "^0.13.1"
@@ -8741,6 +7821,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8791,12 +7872,15 @@
       }
     },
     "node_modules/parse-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
+      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse-package-name": {
@@ -8809,6 +7893,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8817,6 +7902,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8848,6 +7934,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -8880,72 +7967,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-up/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "engines": {
-        "node": ">=4"
-      }
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/plur": {
       "version": "5.1.0",
@@ -8972,29 +7997,43 @@
       }
     },
     "node_modules/pretty-ms": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
+      "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
       "dev": true,
       "dependencies": {
-        "parse-ms": "^2.1.0"
+        "parse-ms": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/private-ip": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-2.3.4.tgz",
-      "integrity": "sha512-ts/YFVwfBeLq61f9+KsOhXW6RH0wvY0gU50R6QZYzgFhggyyLK6WDFeYdjfi/HMnBm2hecLvsR3PB3JcRxDk+A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.0.tgz",
+      "integrity": "sha512-HkMBs4nMtrP+cvcw0bDi2BAZIGgiKI4Zq8Oc+dMqNBpHS8iGL4+WO/pRtc8Bwnv9rjnV0QwMDwEBymFtqv7Kww==",
       "dependencies": {
-        "ip-regex": "^4.3.0",
+        "@chainsafe/is-ip": "^2.0.1",
+        "ip-regex": "^5.0.0",
         "ipaddr.js": "^2.0.1",
-        "is-ip": "^3.1.0",
         "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/private-ip/node_modules/ip-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prop-types": {
@@ -9009,9 +8048,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
+      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -9032,19 +8071,19 @@
       }
     },
     "node_modules/protons-runtime": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-2.0.2.tgz",
-      "integrity": "sha512-6aBGGn4scICr82Emc6+rS1qhxp9I5YUdfaR4lR10BJ6skyQxbh1vEHkrzGqQrawogwbChDrjLG8H6dI+PLh2tg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-4.0.2.tgz",
+      "integrity": "sha512-R4N6qKHgz8T2Gl45CTcZfITzXPQY9ym8lbLb4VyFMS4ag1KusCRZwkQXTBRhxQ+93ck3K3aDhK1wIk98AMtNyw==",
       "dependencies": {
-        "byte-access": "^1.0.1",
-        "longbits": "^1.1.0",
-        "uint8-varint": "^1.0.2",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/punycode": {
@@ -9101,14 +8140,10 @@
         "rabin-wasm": "cli/bin.js"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
+    "node_modules/rate-limiter-flexible": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.1.tgz",
+      "integrity": "sha512-dgH4T44TzKVO9CLArNto62hJOwlWJMLUjVVr/ii0uUzZXEXthDNr7/yefW5z/1vvHAfycc1tnuiYyNJ8CTRB3g=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -9267,6 +8302,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -9280,6 +8316,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -9483,6 +8520,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9553,9 +8591,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -9591,15 +8629,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "peer": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -9688,6 +8717,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -9746,9 +8776,9 @@
       }
     },
     "node_modules/stack-utils": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -9963,7 +8993,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -9972,6 +9001,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -10059,7 +9089,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -10092,6 +9122,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -10099,21 +9130,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/super-regex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
-      "integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
-      "dependencies": {
-        "clone-regexp": "^3.0.0",
-        "function-timeout": "^0.1.0",
-        "time-span": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/stubborn-fs": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
+      "integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w=="
     },
     "node_modules/supertap": {
       "version": "3.0.1",
@@ -10177,12 +9197,12 @@
       }
     },
     "node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       }
     },
     "node_modules/text-table": {
@@ -10190,20 +9210,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
-    },
-    "node_modules/time-span": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
-      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
-      "dependencies": {
-        "convert-hrtime": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/time-zone": {
       "version": "1.0.0",
@@ -10228,6 +9234,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -10252,126 +9259,11 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
-    "node_modules/ts-mocha": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-9.0.2.tgz",
-      "integrity": "sha512-WyQjvnzwrrubl0JT7EC1yWmNpcsU3fOuBFfdps30zbmFBgKniSaSOyZMZx+Wq7kytUs5CY+pEbSYEbGfIKnXTw==",
-      "dependencies": {
-        "ts-node": "7.0.1"
-      },
-      "bin": {
-        "ts-mocha": "bin/ts-mocha"
-      },
-      "engines": {
-        "node": ">= 6.X.X"
-      },
-      "optionalDependencies": {
-        "tsconfig-paths": "^3.5.0"
-      },
-      "peerDependencies": {
-        "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/ts-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-      "dependencies": {
-        "arrify": "^1.0.0",
-        "buffer-from": "^1.1.0",
-        "diff": "^3.1.0",
-        "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^2.0.0"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
       "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
@@ -10403,23 +9295,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/uglify-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
-      "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "peer": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -10429,14 +9308,14 @@
       }
     },
     "node_modules/uint8-varint": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.3.tgz",
-      "integrity": "sha512-ESs/P/AYPy2wWZCT2V6Tg7RPqA6jzlhJbdsNPFvbDeIrDxj12dwTcm0rD9yFlnmgEf6vRBCZrP3d0SiRTcPwSQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.4.tgz",
+      "integrity": "sha512-FHnaReHRIM7kHe/Ms0I2KGkuSY4o7ouhUJGJeiFEuYWGvBt4Y64+BJ3mV6DqmyYtYTZj4Pz8K/BmViSNFLRrVw==",
       "dependencies": {
         "byte-access": "^1.0.0",
         "longbits": "^1.1.0",
         "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.1.0"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -10444,11 +9323,11 @@
       }
     },
     "node_modules/uint8arraylist": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.3.2.tgz",
-      "integrity": "sha512-4ybc/jixmtGhUrebJ0bzB95TjEbskWxBKBRrAozw7P6WcAcZdPMYSLdDuNoEEGo/Cwe+0TNic9CXzWUWzy1quw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
       "dependencies": {
-        "uint8arrays": "^3.1.0"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -10456,11 +9335,15 @@
       }
     },
     "node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
       "dependencies": {
-        "multiformats": "^9.4.2"
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -10482,6 +9365,7 @@
       "version": "5.9.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.9.1.tgz",
       "integrity": "sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==",
+      "dev": true,
       "engines": {
         "node": ">=12.18"
       }
@@ -10522,7 +9406,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -10531,11 +9416,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -10593,6 +9473,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.0.tgz",
+      "integrity": "sha512-H85ulNwUBU1e6PGxkWUDgxnbohSXD++ah6Xw1VHAN7CtypcbZaC4aYjQ+C2PMVaDkURDuOinNAT+Lnz3utWXxQ=="
     },
     "node_modules/wherearewe": {
       "version": "2.0.1",
@@ -10664,12 +9549,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-      "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -10765,31 +9644,32 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
+      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
       "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/ws": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -10848,9 +9728,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -10859,7 +9739,7 @@
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -10871,45 +9751,6 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "peer": true,
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yargs/node_modules/ansi-regex": {
@@ -10969,14 +9810,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -11107,80 +9940,208 @@
         }
       }
     },
+    "@chainsafe/is-ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
+      "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
+    },
     "@chainsafe/libp2p-noise": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-7.0.3.tgz",
-      "integrity": "sha512-kr68a6zEC2y1sp9O1i8MlPu7LgC4U1sLciG/SF9Hvo0kOdDa5a13l3Il9R3rTIqaL9DoVfmQhfpOR/cxY2PWUw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.1.tgz",
+      "integrity": "sha512-pByMPsbuuiAherDV7DRB/sBmxWJcLt2tkuST4vFpv6FZb3/AxKp+ck2f4pHFNaUCaFbGLQa2wN903i8tq8Qr7Q==",
       "requires": {
-        "@libp2p/crypto": "^1.0.0",
-        "@libp2p/interface-connection-encrypter": "^1.0.2",
-        "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interface-peer-id": "^1.0.2",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/peer-collections": "^2.0.0",
-        "@libp2p/peer-id": "^1.1.8",
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-connection-encrypter": "^3.0.5",
+        "@libp2p/interface-keys": "^1.0.6",
+        "@libp2p/interface-metrics": "^4.0.4",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
         "@stablelib/chacha20poly1305": "^1.0.1",
         "@stablelib/hkdf": "^1.0.1",
         "@stablelib/sha256": "^1.0.1",
-        "@stablelib/x25519": "^1.0.1",
+        "@stablelib/x25519": "^1.0.3",
         "it-length-prefixed": "^8.0.2",
         "it-pair": "^2.0.2",
-        "it-pb-stream": "^2.0.1",
+        "it-pb-stream": "^2.0.2",
         "it-pipe": "^2.0.3",
         "it-stream-types": "^1.0.4",
-        "protons-runtime": "^2.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "protons-runtime": "^4.0.1",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
       },
       "dependencies": {
-        "it-length-prefixed": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-          "integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
+        "it-merge": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+          "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
           "requires": {
-            "err-code": "^3.0.1",
-            "it-stream-types": "^1.0.4",
-            "uint8-varint": "^1.0.1",
-            "uint8arraylist": "^2.0.0",
-            "uint8arrays": "^3.0.0"
+            "it-pushable": "^3.1.0"
           }
         },
         "it-pipe": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-          "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+          "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
           "requires": {
-            "it-merge": "^1.0.4",
+            "it-merge": "^2.0.0",
             "it-pushable": "^3.1.0",
             "it-stream-types": "^1.0.3"
           }
-        },
-        "it-pushable": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-          "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
         }
       }
     },
-    "@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "requires": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      }
-    },
     "@esbuild/android-arm": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.10.tgz",
-      "integrity": "sha512-FNONeQPy/ox+5NBkcSbYJxoXj9GWu8gVGJTVmUyoOCKQFDTrHVKgNSzChdNt0I8Aj/iKcsDf2r9BFwv+FSNUXg==",
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.11.tgz",
+      "integrity": "sha512-CdyX6sRVh1NzFCsf5vw3kULwlAhfy9wVt8SZlrhQ7eL2qBjGbFhRBWkkAzuZm9IIEOCKJw4DXA6R85g+qc8RDw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.11.tgz",
+      "integrity": "sha512-QnK4d/zhVTuV4/pRM4HUjcsbl43POALU2zvBynmrrqZt9LPcLA3x1fTZPBg2RRguBQnJcnU059yKr+bydkntjg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.11.tgz",
+      "integrity": "sha512-3PL3HKtsDIXGQcSCKtWD/dy+mgc4p2Tvo2qKgKHj9Yf+eniwFnuoQ0OUhlSfAEpKAFzF9N21Nwgnap6zy3L3MQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.11.tgz",
+      "integrity": "sha512-pJ950bNKgzhkGNO3Z9TeHzIFtEyC2GDQL3wxkMApDEghYx5Qers84UTNc1bAxWbRkuJOgmOha5V0WUeh8G+YGw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.11.tgz",
+      "integrity": "sha512-iB0dQkIHXyczK3BZtzw1tqegf0F0Ab5texX2TvMQjiJIWXAfM4FQl7D909YfXWnB92OQz4ivBYQ2RlxBJrMJOw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.11.tgz",
+      "integrity": "sha512-7EFzUADmI1jCHeDRGKgbnF5sDIceZsQGapoO6dmw7r/ZBEKX7CCDnIz8m9yEclzr7mFsd+DyasHzpjfJnmBB1Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.11.tgz",
+      "integrity": "sha512-iPgenptC8i8pdvkHQvXJFzc1eVMR7W2lBPrTE6GbhR54sLcF42mk3zBOjKPOodezzuAz/KSu8CPyFSjcBMkE9g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.11.tgz",
+      "integrity": "sha512-M9iK/d4lgZH0U5M1R2p2gqhPV/7JPJcRz+8O8GBKVgqndTzydQ7B2XGDbxtbvFkvIs53uXTobOhv+RyaqhUiMg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.11.tgz",
+      "integrity": "sha512-Qxth3gsWWGKz2/qG2d5DsW/57SeA2AmpSMhdg9TSB5Svn2KDob3qxfQSkdnWjSd42kqoxIPy3EJFs+6w1+6Qjg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.11.tgz",
+      "integrity": "sha512-dB1nGaVWtUlb/rRDHmuDQhfqazWE0LMro/AIbT2lWM3CDMHJNpLckH+gCddQyhhcLac2OYw69ikUMO34JLt3wA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-loong64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.10.tgz",
-      "integrity": "sha512-w0Ou3Z83LOYEkwaui2M8VwIp+nLi/NA60lBLMvaJ+vXVMcsARYdEzLNE7RSm4+lSg4zq4d7fAVuzk7PNQ5JFgg==",
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.11.tgz",
+      "integrity": "sha512-aCWlq70Q7Nc9WDnormntGS1ar6ZFvUpqr8gXtO+HRejRYPweAFQN615PcgaSJkZjhHp61+MNLhzyVALSF2/Q0g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.11.tgz",
+      "integrity": "sha512-cGeGNdQxqY8qJwlYH1BP6rjIIiEcrM05H7k3tR7WxOLmD1ZxRMd6/QIOWMb8mD2s2YJFNRuNQ+wjMhgEL2oCEw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.11.tgz",
+      "integrity": "sha512-BdlziJQPW/bNe0E8eYsHB40mYOluS+jULPCjlWiHzDgr+ZBRXPtgMV1nkLEGdpjrwgmtkZHEGEPaKdS/8faLDA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.11.tgz",
+      "integrity": "sha512-MDLwQbtF+83oJCI1Cixn68Et/ME6gelmhssPebC40RdJaect+IM+l7o/CuG0ZlDs6tZTEIoxUe53H3GmMn8oMA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.11.tgz",
+      "integrity": "sha512-4N5EMESvws0Ozr2J94VoUD8HIRi7X0uvUv4c0wpTHZyZY9qpaaN7THjosdiW56irQ4qnJ6Lsc+i+5zGWnyqWqQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.11.tgz",
+      "integrity": "sha512-rM/v8UlluxpytFSmVdbCe1yyKQd/e+FmIJE2oPJvbBo+D0XVWi1y/NQ4iTNx+436WmDHQBjVLrbnAQLQ6U7wlw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.11.tgz",
+      "integrity": "sha512-4WaAhuz5f91h3/g43VBGdto1Q+X7VEZfpcWGtOFXnggEuLvjV+cP6DyLRU15IjiU9fKLLk41OoJfBFN5DhPvag==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.11.tgz",
+      "integrity": "sha512-UBj135Nx4FpnvtE+C8TWGp98oUgBcmNmdYgl5ToKc0mBHxVVqVE7FUS5/ELMImOp205qDAittL6Ezhasc2Ev/w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.11.tgz",
+      "integrity": "sha512-1/gxTifDC9aXbV2xOfCbOceh5AlIidUrPsMpivgzo8P8zUtczlq1ncFpeN1ZyQJ9lVs2hILy1PG5KPp+w8QPPg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.11.tgz",
+      "integrity": "sha512-vtSfyx5yRdpiOW9yp6Ax0zyNOv9HjOAw8WaZg3dF5djEHKKm3UnoohftVvIJtRh0Ec7Hso0RIdTqZvPXJ7FdvQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.11.tgz",
+      "integrity": "sha512-GFPSLEGQr4wHFTiIUJQrnJKZhZjjq4Sphf+mM76nQR6WkQn73vm7IsacmBRPkALfpOCHsopSvLgqdd4iUW2mYw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.11.tgz",
+      "integrity": "sha512-N9vXqLP3eRL8BqSy8yn4Y98cZI2pZ8fyuHx6lKjiG2WABpT2l01TXdzq5Ma2ZUBzfB7tx5dXVhge8X9u0S70ZQ==",
       "dev": true,
       "optional": true
     },
@@ -11242,856 +10203,563 @@
       "dev": true
     },
     "@ipld/car": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-4.1.5.tgz",
-      "integrity": "sha512-PFj4XsKOsxu5h12JUoBJ+mrAVqeA8YYq2bZbcE2sAIopJTwJIB5sBVTmc8ylkUsFXEysZQ4xQD+rZb3Ct0lbjQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.0.tgz",
+      "integrity": "sha512-k9pO0YqJvmFGY5pJDhF2Ocz+mRp3C3r4ikr1NrUXkzN/z4JzhE7XbQzUCcm7daq8k4tRqap0fWPjxZwjS9PUcQ==",
       "requires": {
-        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-cbor": "^9.0.0",
         "cborg": "^1.9.0",
-        "multiformats": "^9.5.4",
+        "multiformats": "^11.0.0",
         "varint": "^6.0.0"
       }
     },
     "@ipld/dag-cbor": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
-      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
+      "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
       "requires": {
-        "cborg": "^1.6.0",
-        "multiformats": "^9.5.4"
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
       }
     },
     "@ipld/dag-json": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
-      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
+      "integrity": "sha512-XE1Eqw3eNVrSfOhtqCM/gwCxEgYFBzkDlkwhEeMmMvhd0rLBfSyVzXbahZSlv97tiTPEIx5rt41gcFAda3W8zg==",
       "requires": {
-        "cborg": "^1.5.4",
-        "multiformats": "^9.5.4"
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
       }
     },
     "@ipld/dag-pb": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
-      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
+      "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
       "requires": {
-        "multiformats": "^9.5.4"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "@libp2p/connection": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/connection/-/connection-2.0.4.tgz",
-      "integrity": "sha512-YGMa0ZTbKdyu4b58mLdVT3XKgfBGp/R5h2FTT/8sB3fHTkJ6Crl3Ad5a+cVuqsWfJhrHDncU3SJaqFH4fxhLmg==",
-      "requires": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1"
-      },
-      "dependencies": {
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
-        }
+        "multiformats": "^11.0.0"
       }
     },
     "@libp2p/crypto": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.4.tgz",
-      "integrity": "sha512-3hHZvqi+vI8YoTHE+0u8nA5SYGPLZRLMvbgXQoAn0IyPjez66Taaxym/3p3Duf9QkFlvJu95nzpNzv0OdHs9Yw==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.14.tgz",
+      "integrity": "sha512-kS9bsRPS6qrbGiMfICjVUTjva7Bq0kCE0DTVGgFixH8e2RtF/7K8bWzO52aTQVPUF7vpId7cmmYAaHde1ZYh0A==",
       "requires": {
         "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interfaces": "^3.2.0",
         "@noble/ed25519": "^1.6.0",
         "@noble/secp256k1": "^1.5.4",
-        "err-code": "^3.0.1",
-        "multiformats": "^9.4.5",
+        "multiformats": "^11.0.0",
         "node-forge": "^1.1.0",
-        "protons-runtime": "^3.1.0",
-        "uint8arrays": "^3.0.0"
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
       },
       "dependencies": {
         "protons-runtime": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-3.1.0.tgz",
-          "integrity": "sha512-S1iSPQC0McdHKJRi0XcATBkWgwWPx46UDfrnshYDXBvGHSYqkFtn4MQ8Gatf67w7FzFtHivA+Hb0ZPq56upG8w==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+          "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
           "requires": {
             "protobufjs": "^7.0.0",
-            "uint8arraylist": "^2.3.2"
+            "uint8arraylist": "^2.4.3"
           }
         }
+      }
+    },
+    "@libp2p/interface-address-manager": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-address-manager/-/interface-address-manager-2.0.4.tgz",
+      "integrity": "sha512-RcSi+z+xpVKJXq3BsfLf2rq8zb8VTAFown6uJBu02towMc0enYqqhwlV9DxcCaC573MgQ7gY2s/3XvxQdFraVA==",
+      "requires": {
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
       }
     },
     "@libp2p/interface-connection": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.2.tgz",
-      "integrity": "sha512-38R2GQ6BCOtwMi5uWU5MLr+xfEpRmVK9gqOp7jNx+6T7TVn8ji4725XLXNfpzprbOrzZkqf2iER84s8+yX4pMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.1.0.tgz",
+      "integrity": "sha512-UfluPclTyJp5nBVKQVJ7Xrwp45fFYeIPuyfCpZfTKOfT/srSntA5l+094H6f1bGSj6SbwZ4V7BxCxviJQM5PBg==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0",
         "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.1.1"
-      },
-      "dependencies": {
-        "@libp2p/interfaces": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-          "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag=="
-        },
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "dns-over-http-resolver": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-          "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-          "requires": {
-            "debug": "^4.3.1",
-            "native-fetch": "^4.0.2",
-            "receptacle": "^1.3.2"
-          }
-        },
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        },
-        "is-ip": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-          "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-          "requires": {
-            "ip-regex": "^5.0.0",
-            "super-regex": "^0.2.0"
-          }
-        },
-        "native-fetch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-          "requires": {}
-        }
+        "uint8arraylist": "^2.1.2"
       }
     },
     "@libp2p/interface-connection-encrypter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-1.0.3.tgz",
-      "integrity": "sha512-3HNg52HmanRuV2rbQRMFUVTPceSqoC1+ifK9Jkqw3mbiTXXf1mdsv5uKbqts6QvNY5ABZeQWuqJb2QqibaI0mw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
+      "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "it-stream-types": "^1.0.4"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      }
+    },
+    "@libp2p/interface-connection-manager": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.3.7.tgz",
+      "integrity": "sha512-GyRa7FXtwjbch4ucFa/jj6vcaQT2RyhUbH3q0tIOTzjntABTMzQrhn3BWOGU5deRp2K7cVOB/OzrdhHdGUxYQA==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
+      }
+    },
+    "@libp2p/interface-content-routing": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.0.2.tgz",
+      "integrity": "sha512-SlyZnBk+IpTKdT/4RMNTHcl18PRWUXfb3qhkBPP8xBNGm57DxApKQjLjoklSRNwJ3VDmXyPqTpiR/K/pLPow6A==",
+      "requires": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      }
+    },
+    "@libp2p/interface-dht": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-dht/-/interface-dht-2.0.1.tgz",
+      "integrity": "sha512-+yEbt+1hMTR1bITzYyE771jEujimPXqDyFm8T1a8slMpeOD9z5wmLfuCWif8oGZJzXX5YqldWwSwytJQgWXL9g==",
+      "requires": {
+        "@libp2p/interface-peer-discovery": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      }
+    },
+    "@libp2p/interface-keychain": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.4.tgz",
+      "integrity": "sha512-RCH0PL9um/ejsPiWIOzxFzjPzL2nT2tRUtCDo1aBQqoBi7eYp4I4ya1KbzgWDPTmNuuFtCReRMQsZ7/KVirKPA==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "multiformats": "^11.0.0"
       }
     },
     "@libp2p/interface-keys": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.3.tgz",
-      "integrity": "sha512-K8/HlRl/swbVTWuGHNHF28EytszYfUhKgUHfv8CdbMk9ZA/bgO4uU+d9rcrg/Dhw3511U3aRz2bwl2psn6rJfg=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.7.tgz",
+      "integrity": "sha512-DRMPY9LfcnGJKrjaqIkY62U3fW2dya3VLy4x986ExtMrGn4kxIHeQ1IKk8/Vs9CJHTKmXEMID4of1Cjnw4aJpA=="
+    },
+    "@libp2p/interface-libp2p": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-libp2p/-/interface-libp2p-1.1.1.tgz",
+      "integrity": "sha512-cELZZv/tzFxbUzL3Jvbk+AM2J6kDhIUNBIMMMLuR3LIHfmVJkh31G3ChLUZuKhBwB8wXJ1Ssev3fk1tfz/5DWA==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interface-keychain": "^2.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interface-peer-routing": "^1.0.0",
+        "@libp2p/interface-peer-store": "^1.0.0",
+        "@libp2p/interface-pubsub": "^3.0.0",
+        "@libp2p/interface-registrar": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
+      }
+    },
+    "@libp2p/interface-metrics": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
+      "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0"
+      }
+    },
+    "@libp2p/interface-peer-discovery": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-discovery/-/interface-peer-discovery-1.0.5.tgz",
+      "integrity": "sha512-R0TN/vDaCJLvRhop0y4qoPqapHxX4AEQDEtqmpayAA1BuPgbBq4fS4mepR3FAMcNva/szeqVCDuI4gDejtCaVg==",
+      "requires": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      }
     },
     "@libp2p/interface-peer-id": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-1.0.4.tgz",
-      "integrity": "sha512-VRnE0MqmS1kN43hyKCEdkhz0gciuDML7hpL3p8zDm0LnveNMLJsR+/VSUaugCi/muOzLaLk26WffKWbMYfnGfA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
       "requires": {
-        "multiformats": "^9.6.3"
+        "multiformats": "^11.0.0"
       }
     },
     "@libp2p/interface-peer-info": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.3.tgz",
-      "integrity": "sha512-QKybxfp/NmDGDMkgf/CTt4fU03ajZnldHr9TYg5wMkJrnVaaHbhDTYBg5YWt+iOH1mgR89/dpKv/Na0ZE5sPIA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.8.tgz",
+      "integrity": "sha512-LRvZt/9bZFYW7seAwuSg2hZuPl+FRTAsij5HtyvVwmpfVxipm6yQrKjQ+LiK/SZhIDVsSJ+UjF0mluJj+jeAzQ==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "@multiformats/multiaddr": "^11.0.0"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "dns-over-http-resolver": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-          "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-          "requires": {
-            "debug": "^4.3.1",
-            "native-fetch": "^4.0.2",
-            "receptacle": "^1.3.2"
-          }
-        },
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        },
-        "is-ip": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-          "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-          "requires": {
-            "ip-regex": "^5.0.0",
-            "super-regex": "^0.2.0"
-          }
-        },
-        "native-fetch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-          "requires": {}
-        }
+      }
+    },
+    "@libp2p/interface-peer-routing": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.0.8.tgz",
+      "integrity": "sha512-ArJWymWvHqVNyHSZ+7T9av2A4r0f1zTPMKe3+7BOX3n2mB8hP2nNMz/Kiun41TH0t80zMiXE73ZD29is27yt9g==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
       }
     },
     "@libp2p/interface-peer-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.2.tgz",
-      "integrity": "sha512-ZjE9AkDtjz4R+SppCgZ66oko7Z9pDsdFk1lbba0hTPA2i0uuWdTYep7bZ3RvKot0Q2UrWg8ySL/30pW+Wp70sA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.8.tgz",
+      "integrity": "sha512-FM9VLmpg9CUBKZ2RW+J7RrQfQVMksLiC8oqENqHgb/VkPJY3kafbn7HIi0NcK6H/H5VcwBIhL15SUJk66O1K6g==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-peer-info": "^1.0.0",
         "@libp2p/interface-record": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0"
-      },
-      "dependencies": {
-        "@libp2p/interfaces": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-          "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag=="
-        },
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "dns-over-http-resolver": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-          "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-          "requires": {
-            "debug": "^4.3.1",
-            "native-fetch": "^4.0.2",
-            "receptacle": "^1.3.2"
-          }
-        },
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        },
-        "is-ip": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-          "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-          "requires": {
-            "ip-regex": "^5.0.0",
-            "super-regex": "^0.2.0"
-          }
-        },
-        "native-fetch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-          "requires": {}
-        }
+      }
+    },
+    "@libp2p/interface-pubsub": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.6.tgz",
+      "integrity": "sha512-c1aVHAhxmEh9IpLBgJyCsMscVDl7YUeP1Iq6ILEQoWiPJhNpQqdfmqyk7ZfrzuBU19VFe1EqH0bLuLDbtfysTQ==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-pushable": "^3.0.0",
+        "uint8arraylist": "^2.1.2"
       }
     },
     "@libp2p/interface-record": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.1.tgz",
-      "integrity": "sha512-RqF5jKukI8v3Q8MZb4d8/UVjg0OXbl0R8ErWi/LKf+uklA8kTA7rT4FQXFUBycxrkFmEu/tJnW+R1/4fwRwZVg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.6.tgz",
+      "integrity": "sha512-4EtDkY3sbYapWM8++gVHlv31HZXoLmj9I7CRXUKXzFkVE0GLK/A8jYWl7K0lmf2juPjeYm2eHITeA9/wAtIS3w==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "uint8arraylist": "^2.0.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "uint8arraylist": "^2.1.2"
       }
     },
-    "@libp2p/interface-transport": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-1.0.4.tgz",
-      "integrity": "sha512-MOkhtykUrrbgHC1CcAFe/6QTz/BEBbHfu5sf+go6dhBlHXeHI+AcV8Fic5zTZNz71E1SRi2UR+5TVi7ORPL57Q==",
+    "@libp2p/interface-registrar": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.9.tgz",
+      "integrity": "sha512-+aZg7SB8fIddE4/PojnHY2Y29vwr4YtnXxro3db/TYWAsWNGlgZusFEZYqBMpV/1KpEFBdi3O7r50bv/2fRusQ==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0"
+      }
+    },
+    "@libp2p/interface-stream-muxer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.5.tgz",
+      "integrity": "sha512-815aJ+qVswNcTEOuOUTcB+7OLzAfROyjjqoWpK0bD0P/xqTHqOQcqdaDuK02zPuAZqYq9uR3+SoBasrCg6k3zw==",
       "requires": {
         "@libp2p/interface-connection": "^3.0.0",
         "@libp2p/interfaces": "^3.0.0",
+        "it-stream-types": "^1.0.4"
+      }
+    },
+    "@libp2p/interface-transport": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.1.tgz",
+      "integrity": "sha512-xDM/s8iPN/XfNqD9qNelibRMPKkhOLinXwQeNtoTZjarq+Cg6rtO6/5WBG/49hyI3+r+5jd2eykjPGQbb86NFQ==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interfaces": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0",
         "it-stream-types": "^1.0.4"
-      },
-      "dependencies": {
-        "@libp2p/interfaces": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-          "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag=="
-        },
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "dns-over-http-resolver": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-          "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-          "requires": {
-            "debug": "^4.3.1",
-            "native-fetch": "^4.0.2",
-            "receptacle": "^1.3.2"
-          }
-        },
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        },
-        "is-ip": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-          "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-          "requires": {
-            "ip-regex": "^5.0.0",
-            "super-regex": "^0.2.0"
-          }
-        },
-        "native-fetch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-          "requires": {}
-        }
       }
     },
     "@libp2p/interfaces": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-2.0.4.tgz",
-      "integrity": "sha512-MfwkTFyHJtvwNxkjOjzkXyIVvKFtEW2Q3IGRJPyPQMrtB6ll0rGMTlyJ3BQS1bcD0YkNhggFm+8XiU2/0LCBhQ==",
-      "requires": {
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-pushable": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "multiformats": "^9.6.3"
-      }
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
+      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg=="
     },
     "@libp2p/logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.1.tgz",
-      "integrity": "sha512-Mtj7ImjRYbaANuT53QRqc7ooBYpWieLo7KbqYYGas5O2AWQeOu/zyGBMM35WbWIo7sMuhCas9XBPJdFOR7A05w==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.6.tgz",
+      "integrity": "sha512-PfTGCBT6buiGeww7heG1JucBK2io2sJ2hntNh+gTVohRy4FyEvZixnWfIVD2rCM8EsbZu3Hmt/qqetzX5BrziQ==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.2",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "debug": "^4.3.3",
-        "interface-datastore": "^7.0.0",
-        "multiformats": "^9.6.3"
+        "interface-datastore": "^8.0.0",
+        "multiformats": "^11.0.0"
       },
       "dependencies": {
         "interface-datastore": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.0.tgz",
-          "integrity": "sha512-q9OveOhexQ3Fx8h4YbuR4mZtUHwvlOynKnIwTm6x8oBTWfIyAKtlYtrOYdlHfqQztbYpdzRFcapopNJBMx36NQ==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.0.0.tgz",
+          "integrity": "sha512-RRkUskUnBn4q6pGCMgc3j4t+MxVgj6SNADQPna63/MOvYk36yxj3sJh/8Apj8MLAMtzCosXhbCi82S/9W1z3qg==",
           "requires": {
-            "interface-store": "^3.0.0",
-            "nanoid": "^3.0.2",
-            "uint8arrays": "^3.0.0"
+            "interface-store": "^4.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
           }
         },
         "interface-store": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.0.tgz",
-          "integrity": "sha512-IBJn3hE6hYutwdDcStR76mcwfV98vZc49LkEN9ANHHpsxcm6YbGMJxowO2G3FITU4U5ZH4KJPlHOT6Oe2vzTWA=="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-4.0.0.tgz",
+          "integrity": "sha512-cApTZjtMixGyIVNKw6cFcPJTL0KLEbUslhn7hzaKRonQqjjQxzEnklGZkreqmgbVlwOPLQ06s0Qg6F1yOYzfow=="
+        },
+        "nanoid": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+          "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww=="
         }
       }
     },
     "@libp2p/mplex": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-1.2.2.tgz",
-      "integrity": "sha512-+DHxpxGpnCAvy/q/G2YJY121NMBS3+065DcQkPfFe+hToqmgO9sSJmZbFeOm/AYpauchvVSUvS75dxGdgQ4R9Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.1.tgz",
+      "integrity": "sha512-0owK1aWgXXtjiohXtjwLV7Ehjdj96eBtsapVt7AzlHA+W8uYnI+x058thq3MisyMDlHiiE3BTh6fEf+t2/0dUw==",
       "requires": {
-        "@libp2p/logger": "^1.1.3",
-        "@libp2p/tracked-map": "^1.0.5",
+        "@libp2p/interface-connection": "^3.0.1",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/logger": "^2.0.0",
         "abortable-iterator": "^4.0.2",
         "any-signal": "^3.0.0",
+        "benchmark": "^2.1.4",
         "err-code": "^3.0.1",
-        "it-pipe": "^2.0.3",
-        "it-pushable": "^3.0.0",
+        "it-batched-bytes": "^1.0.0",
+        "it-pushable": "^3.1.0",
         "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.4.0",
-        "uint8arrays": "^3.0.0",
+        "rate-limiter-flexible": "^2.3.9",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
       },
       "dependencies": {
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
-        },
         "any-signal": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
           "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
-        },
-        "it-pipe": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-          "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
-          "requires": {
-            "it-merge": "^1.0.4",
-            "it-pushable": "^3.1.0",
-            "it-stream-types": "^1.0.3"
-          }
-        },
-        "it-pushable": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-          "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-        },
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
-          }
         }
       }
     },
     "@libp2p/multistream-select": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-1.0.6.tgz",
-      "integrity": "sha512-8veeiZDrh7aCvILjNGps4ZLKSKTdBxJZS4SZkuhbCKmq7eX6aJoYoQ5G5MBxEFiBKtgwTKHaSroH3jfvizwDoA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-3.1.2.tgz",
+      "integrity": "sha512-NfF0fwQM4sqiLuNGBVc9z2mfz3OigOfyLJ5zekRBGYHkbKWrBRFS3FligUPr9roCOzH6ojjDkKVd5aK9/llfJQ==",
       "requires": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
+        "@libp2p/interfaces": "^3.0.2",
+        "@libp2p/logger": "^2.0.0",
         "abortable-iterator": "^4.0.2",
         "err-code": "^3.0.1",
-        "it-first": "^1.0.6",
-        "it-handshake": "^3.0.1",
-        "it-length-prefixed": "^7.0.1",
-        "it-pipe": "^2.0.3",
-        "it-pushable": "^2.0.1",
-        "it-reader": "^5.0.0",
+        "it-first": "^2.0.0",
+        "it-handshake": "^4.1.2",
+        "it-length-prefixed": "^8.0.3",
+        "it-merge": "^2.0.0",
+        "it-pipe": "^2.0.4",
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
         "it-stream-types": "^1.0.4",
         "p-defer": "^4.0.0",
-        "uint8arraylist": "^1.5.1",
-        "uint8arrays": "^3.0.0"
+        "uint8arraylist": "^2.3.1",
+        "uint8arrays": "^4.0.2"
       },
       "dependencies": {
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
+        "it-first": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
+          "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw=="
         },
-        "it-handshake": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-3.0.1.tgz",
-          "integrity": "sha512-Rx9ESanlfnC0aMw2LtLJ9YNlCNgnZU7wOHPzPSZTUAjbdZx54kllGR5ndIuoJqF2EtNIsmTiWEncKTgwHNJSSg==",
+        "it-merge": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+          "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
           "requires": {
-            "it-map": "^1.0.6",
-            "it-pushable": "^2.0.1",
-            "it-reader": "^5.0.0",
-            "it-stream-types": "^1.0.4",
-            "p-defer": "^4.0.0"
+            "it-pushable": "^3.1.0"
           }
         },
         "it-pipe": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-          "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+          "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
           "requires": {
-            "it-merge": "^1.0.4",
+            "it-merge": "^2.0.0",
             "it-pushable": "^3.1.0",
             "it-stream-types": "^1.0.3"
-          },
-          "dependencies": {
-            "it-pushable": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-              "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-            }
-          }
-        },
-        "it-reader": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-5.0.2.tgz",
-          "integrity": "sha512-OgcWA/ffAALrkuUN2sQsbKa3of5oOyLvlXJgSCZdn9sSLZ0rnNmtsJ3lP/WEfWJH8aUNs3bfG6ja3QXKcCOwFw==",
-          "requires": {
-            "it-stream-types": "^1.0.4",
-            "uint8arraylist": "^1.2.0"
-          }
-        },
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
           }
         }
       }
     },
     "@libp2p/peer-collections": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-2.2.0.tgz",
-      "integrity": "sha512-fLHWRms2aiSplZcTfXz6bLGZ62f1jfcW3EkS/TweVRpbWpzbtkW+V1CKkhlF3Qc4pJl7GTA5HAfPWIrVDvBYag==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-3.0.0.tgz",
+      "integrity": "sha512-rVhfDmkVzfBVR4scAfaKb05htZENx01PYt2USi1EnODyoo2c2U2W5tfOfyaKI/4D+ayQDOjT27G0ZCyAgwkYGw==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.4",
-        "@libp2p/peer-id": "^1.1.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0"
       }
     },
     "@libp2p/peer-id": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-1.1.15.tgz",
-      "integrity": "sha512-Y33JLEfsLmLUjuC2nhQ2lBXP6PIsR892gSsNy4Vd7oILkuRhjPouIojP9BbME0m9bhVbAws+Zh9NBKtp7UH7wA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.2.tgz",
+      "integrity": "sha512-RBjCMtSLnX43OK6zIpMW/cKzEgnsunihgyVPhnB/U7DAAEnovxe8F1Q4jBQp9+9DYSgQJrsdiEBpT5JH0Eh2lA==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "err-code": "^3.0.1",
-        "multiformats": "^9.6.3",
-        "uint8arrays": "^3.0.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2"
       }
     },
     "@libp2p/peer-id-factory": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-1.0.18.tgz",
-      "integrity": "sha512-x7lyPrfF4kkMj6az+h1sq5L6ifTvZt2exKi8yS6/Gi/hT8rfqXROdBDtanMjJivIFlzVKJyZdfW5f5RK9Av3iQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.2.tgz",
+      "integrity": "sha512-cnny4gkZf1HQ7aZVeZii3xY4DBSPW+O29GvnhECRF55SkRa5xzkZMVnoKX2d+9wBbS4t3ng2kOF2HtgSIySfWw==",
       "requires": {
         "@libp2p/crypto": "^1.0.0",
         "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "@libp2p/peer-id": "^1.0.0",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^3.1.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "uint8arrays": "^4.0.2"
       },
       "dependencies": {
         "protons-runtime": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-3.1.0.tgz",
-          "integrity": "sha512-S1iSPQC0McdHKJRi0XcATBkWgwWPx46UDfrnshYDXBvGHSYqkFtn4MQ8Gatf67w7FzFtHivA+Hb0ZPq56upG8w==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+          "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
           "requires": {
             "protobufjs": "^7.0.0",
-            "uint8arraylist": "^2.3.2"
+            "uint8arraylist": "^2.4.3"
           }
         }
       }
     },
     "@libp2p/peer-record": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-1.0.12.tgz",
-      "integrity": "sha512-1b4aeU4sduRBUH4RKDtYBHKOEXwohrlOoBrrNPKb1WFweLMnG3oznhGusMvKQ8YuXSOTpbNPHrbJ/iJnrBbVUQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.2.tgz",
+      "integrity": "sha512-Cqaj3pC9zQHKE1FYE7B1OcMVWQkQNjLaSH2ioavz3PMPWGy+5m4dVK9hvSyoEf8PfRKFT+x92MONbappEFBwvg==",
       "requires": {
-        "@libp2p/crypto": "^0.22.8",
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@libp2p/peer-id": "^1.1.0",
-        "@libp2p/utils": "^1.0.9",
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-filter": "^1.0.3",
-        "it-foreach": "^0.1.1",
-        "it-map": "^1.0.6",
-        "it-pipe": "^2.0.3",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/utils": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.2",
+        "uint8arraylist": "^2.1.0",
+        "uint8arrays": "^4.0.2"
       },
       "dependencies": {
-        "@libp2p/crypto": {
-          "version": "0.22.14",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-0.22.14.tgz",
-          "integrity": "sha512-5RyGh5ovfqrDD8Io3n5rvVnsTHBf1exIMZ/5eBw7Eoy21xkmzdF1Hy701SoSNmiCuTPXYmxT5WMy2VUDBUG6oQ==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.1",
-            "@noble/ed25519": "^1.6.0",
-            "@noble/secp256k1": "^1.5.4",
-            "err-code": "^3.0.1",
-            "iso-random-stream": "^2.0.0",
-            "multiformats": "^9.4.5",
-            "node-forge": "^1.1.0",
-            "protons-runtime": "^1.0.4",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
-        },
-        "@libp2p/utils": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-1.0.10.tgz",
-          "integrity": "sha512-jlVLfac1IoBlgXL8V+XZYxNw0SOAkKweiLhXWolUbKOgRtMDquJzbwG1n8y9GtdiFKPlkiBwOB7l9xighcOR6w==",
-          "requires": {
-            "@achingbrain/ip-address": "^8.1.0",
-            "@libp2p/logger": "^1.0.1",
-            "@multiformats/multiaddr": "^10.1.1",
-            "abortable-iterator": "^4.0.2",
-            "err-code": "^3.0.1",
-            "is-loopback-addr": "^2.0.1",
-            "it-stream-types": "^1.0.4",
-            "private-ip": "^2.1.1",
-            "ts-mocha": "^9.0.2",
-            "ts-node": "^10.7.0"
-          }
-        },
-        "it-pipe": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-          "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
-          "requires": {
-            "it-merge": "^1.0.4",
-            "it-pushable": "^3.1.0",
-            "it-stream-types": "^1.0.3"
-          }
-        },
-        "it-pushable": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-          "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-        },
         "protons-runtime": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-          "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+          "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
           "requires": {
-            "uint8arraylist": "^1.4.0",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
+            "protobufjs": "^7.0.0",
+            "uint8arraylist": "^2.4.3"
           }
         }
       }
     },
     "@libp2p/peer-store": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-1.0.17.tgz",
-      "integrity": "sha512-1uvwjJ2dRQyQnms+vBY3CgWpZe+0EYSoCNo7UUE6dhJHIA3q1Syl4kZWukA081m1eFzmMLG2VjsrzUQAfmy+Sw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-6.0.4.tgz",
+      "integrity": "sha512-yw7XbeJ5k880PpkDV/HcSZtj0vQ0ShPbnCzVHc1hW0JS/g1vhpSooAZOf3w65obUoFhUwccnSZ4HSLBSpQqOaA==",
       "requires": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@libp2p/peer-id": "^1.1.0",
-        "@libp2p/peer-record": "^1.0.0",
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-filter": "^1.0.3",
-        "it-foreach": "^0.1.1",
-        "it-map": "^1.0.6",
-        "it-pipe": "^2.0.3",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-store": "^1.2.2",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-foreach": "^1.0.0",
+        "it-map": "^2.0.0",
         "mortice": "^3.0.0",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0"
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2"
       },
       "dependencies": {
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
+        "interface-datastore": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+          "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
           "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
+            "interface-store": "^3.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
           }
         },
-        "it-pipe": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-          "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
-          "requires": {
-            "it-merge": "^1.0.4",
-            "it-pushable": "^3.1.0",
-            "it-stream-types": "^1.0.3"
-          }
+        "interface-store": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+          "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
         },
-        "it-pushable": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-          "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
+        "it-all": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+          "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA=="
+        },
+        "it-filter": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+          "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg=="
+        },
+        "it-map": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+          "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ=="
+        },
+        "nanoid": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+          "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww=="
         },
         "protons-runtime": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-          "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+          "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
           "requires": {
-            "uint8arraylist": "^1.4.0",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
+            "protobufjs": "^7.0.0",
+            "uint8arraylist": "^2.4.3"
           }
         }
       }
     },
     "@libp2p/tcp": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-3.1.2.tgz",
-      "integrity": "sha512-b2xrzmAx0ktlgzsSgaqeHjtnVNzZeYPZPtgjbGub9zEWHZFuN4XER9XppdCMbvQw/68RHufuSQu8PEDMv5l4VQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-6.1.2.tgz",
+      "integrity": "sha512-IKxcAO4qHRgGLT2aqsy2ayUmkra38efJ5mla4lDECjxcUqHnbok+QEPIgDodPbTaEgfbd6ivmwP1YxHLxt9dJA==",
       "requires": {
         "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-transport": "^1.0.4",
-        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-transport": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/utils": "^3.0.2",
         "@multiformats/mafmt": "^11.0.3",
         "@multiformats/multiaddr": "^11.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
         "stream-to-it": "^0.2.2"
-      },
-      "dependencies": {
-        "@libp2p/interfaces": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-          "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag=="
-        },
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "dns-over-http-resolver": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-          "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-          "requires": {
-            "debug": "^4.3.1",
-            "native-fetch": "^4.0.2",
-            "receptacle": "^1.3.2"
-          }
-        },
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        },
-        "is-ip": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-          "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-          "requires": {
-            "ip-regex": "^5.0.0",
-            "super-regex": "^0.2.0"
-          }
-        },
-        "native-fetch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-          "requires": {}
-        }
       }
     },
     "@libp2p/tracked-map": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-1.0.8.tgz",
-      "integrity": "sha512-tN56iEdSbDuUhDApQV0k93aIQu/vACN8fNHsaWZrFpvwPaXmLb//jn3m34pwnSyaTPjUSendP25+JDzg/2U/mw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-3.0.2.tgz",
+      "integrity": "sha512-mtsZWf2ntttuCrmEIro2p1ceCAaKde2TzT/99DZlkGdJN/Mo1jZgXq7ltZjWc8G3DAlgs+0ygjMzNKcZzAveuQ==",
       "requires": {
-        "@libp2p/interfaces": "^2.0.0"
+        "@libp2p/interface-metrics": "^4.0.0"
       }
     },
     "@libp2p/utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.2.tgz",
-      "integrity": "sha512-/+mwCEd1o1sko3fYkVfy9pDT3Ks+KszR4Y3fb3M3/UCETDituvqZKHHM4wyTJsFlrFrohbtYlNvWhJ7Pej3X5g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.4.tgz",
+      "integrity": "sha512-EWJNJtlop2ylmGE1BNiMA0u4eTLKoY0LbZ/DOvSDs9VlGSLua9J+LUjp6XV8lazGv7l1rOLiU+1hP5fcmg1+eg==",
       "requires": {
         "@achingbrain/ip-address": "^8.1.0",
         "@libp2p/interface-connection": "^3.0.2",
@@ -12102,62 +10770,17 @@
         "err-code": "^3.0.1",
         "is-loopback-addr": "^2.0.1",
         "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
+        "private-ip": "^3.0.0",
         "uint8arraylist": "^2.3.2"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "dns-over-http-resolver": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-          "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-          "requires": {
-            "debug": "^4.3.1",
-            "native-fetch": "^4.0.2",
-            "receptacle": "^1.3.2"
-          }
-        },
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        },
-        "is-ip": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-          "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-          "requires": {
-            "ip-regex": "^5.0.0",
-            "super-regex": "^0.2.0"
-          }
-        },
-        "native-fetch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-          "requires": {}
-        }
       }
     },
     "@libp2p/websockets": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-3.0.4.tgz",
-      "integrity": "sha512-Xu2ENTcc05D+QALo7ayVlMJjKPUoABToUve1JQQmfH2Pb6ck1fACmjLTTpumoRDNm6UZTbkW1k8SgUmzg57iiw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.5.tgz",
+      "integrity": "sha512-gp6OI/2cBBkbUKw7XougNC8/XZe1fe5eSngWDSE99/wGykwDzyKPnYikUAGhJ4X1VuBDAjogZuJp7PtDif1QPQ==",
       "requires": {
         "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-transport": "^1.0.4",
+        "@libp2p/interface-transport": "^2.0.0",
         "@libp2p/interfaces": "^3.0.3",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/utils": "^3.0.2",
@@ -12165,100 +10788,52 @@
         "@multiformats/multiaddr": "^11.0.0",
         "@multiformats/multiaddr-to-uri": "^9.0.2",
         "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "it-ws": "^5.0.0",
+        "it-ws": "^5.0.6",
         "p-defer": "^4.0.0",
         "p-timeout": "^6.0.0",
-        "wherearewe": "^2.0.1"
+        "wherearewe": "^2.0.1",
+        "ws": "^8.12.1"
       },
       "dependencies": {
-        "@libp2p/interfaces": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-          "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag=="
-        },
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "dns-over-http-resolver": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-          "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-          "requires": {
-            "debug": "^4.3.1",
-            "native-fetch": "^4.0.2",
-            "receptacle": "^1.3.2"
-          }
-        },
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        },
-        "is-ip": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-          "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-          "requires": {
-            "ip-regex": "^5.0.0",
-            "super-regex": "^0.2.0"
-          }
-        },
-        "native-fetch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-          "requires": {}
-        },
         "p-timeout": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
-          "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA=="
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
+          "integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w=="
         }
       }
     },
     "@miniflare/cache": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.10.0.tgz",
-      "integrity": "sha512-nzEqFVPnD7Yf0HMDv7gCPpf4NSXfjhc+zg3gSwUS4Dad5bWV10B1ujTZW6HxQulW3CBHIg616mTjXIiaimVuEQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.9.0.tgz",
+      "integrity": "sha512-lriPxUEva9TJ01vU9P7pI60s3SsFnb4apWkNwZ+D7CRqyXPipSbapY8BWI2FUIwkEG7xap6UhzeTS76NettCXQ==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "5.9.1"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.10.0.tgz",
-      "integrity": "sha512-NAiCtqlHTUKCmV+Jl9af+ixGmMhiGhIyIfr/vCdbismNEBxEsrQGg3sQYTNfvCkdHtODurQqayQreFq21OuEow==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.9.0.tgz",
+      "integrity": "sha512-gu8Z7NWNcYw6514/yOvajaj3GmebRucx+EEt3p1vKirO+gvFgKAt/puyUN3p7u8ZZmLuLF/B+wVnH3lj8BWKlg==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/shared": "2.9.0",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-Jx1M5oXQua0jzsJVdZSq07baVRmGC/6JkglrPQGAlZ7gQ1sunVZzq9fjxFqj0bqfEuYS0Wy6+lvK4rOAHISIjw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-QqSwF6oHvgrFvN5lnrLc6EEagFlZWW+UMU8QdrE8305cNGHrIOxKCA2nte4PVFZUVw/Ts13a0tVhUk3a2fAyxQ==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/watcher": "2.10.0",
+        "@miniflare/queues": "2.9.0",
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/watcher": "2.9.0",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -12268,48 +10843,48 @@
       }
     },
     "@miniflare/d1": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.10.0.tgz",
-      "integrity": "sha512-mOYZSmpTthH0tmFTQ+O9G0Q+iDAd7oiUtoIBianlKa9QiqYAoO7EBUPy6kUgDHXapOcN5Ri1u3J5UTpxXvw3qg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.9.0.tgz",
+      "integrity": "sha512-swK9nzxw1SvVh/4cH3bRR1SBuHQU/YsB8WvuHojxufmgviAD1xhms3XO3rkpAzfKoGM5Oy6DovMe0xUXV/GS0w==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0"
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.10.0.tgz",
-      "integrity": "sha512-gU45f52gveFtCasm0ixYnt0mHI1lHrPomtmF+89oZGKBzOqUfO5diDs6wmoRSnovOWZCwtmwQGRoorAQN7AmoA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.9.0.tgz",
+      "integrity": "sha512-7uTvfEUXS7xqwrsWOwWrFUuKc4EiMpVkAWPeYGLB/0TJaJ6N+sZMpYYymdW79TQwPIDfgtpfkIy93MRydqpnrw==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/storage-memory": "2.9.0",
         "undici": "5.9.1"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.10.0.tgz",
-      "integrity": "sha512-hCdG99L8+Ros4dn3B5H37PlQPBH0859EoRslzNTd4jzGIkwdiawpJvrvesL8056GjbUjeJN1zh7OPBRuMgyGLw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.9.0.tgz",
+      "integrity": "sha512-K5OB70PtkMo7M+tU46s/cX/j/qtjD9AlJ0hecYswrxVsfrT/YWyrCQJevmShFfJ92h7jPNigbeC3Od3JiVb6QA==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "5.9.1"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.10.0.tgz",
-      "integrity": "sha512-cm6hwkONucll93yoY8dteMp//Knvmb7n6zAgeHrtuNYKn//lAL6bRY//VLTttrMmfWxZFi1C7WpOeCv8Mn6/ug==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.9.0.tgz",
+      "integrity": "sha512-IVJMkFfMpecq9WiCTvATEKhMuKPK9fMs2E6zmgexaefr3u1VlNtj2QxBxoPUXkT9xMJQlT5sSKstlRR1XKDz9Q==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/web-sockets": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/web-sockets": "2.9.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "5.9.1",
@@ -12318,57 +10893,57 @@
       }
     },
     "@miniflare/kv": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.10.0.tgz",
-      "integrity": "sha512-3+u1lO77FnlS0lQ6b1VgM1E/ZgQ/zy/FU+SdBG5LUOIiv3x522VYHOApeJLnSEo0KtZUB22Ni0fWQM6DgpaREg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.9.0.tgz",
+      "integrity": "sha512-EqG51okY5rDtgjYs2Ny6j6IUVdTlJzDjwBKBIuW+wOV9NsAAzEchKVdYAXc8CyxvkggpYX481HydTD2OzK3INQ==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.9.0"
       }
     },
     "@miniflare/queues": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.10.0.tgz",
-      "integrity": "sha512-WKdO6qI9rfS96KlCjazzPFf+qj6DPov4vONyf18+jzbRjRJh/xwWSk1/1h5A+gDPwVNG8TsNRPh9DW5OKBGNjw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.9.0.tgz",
+      "integrity": "sha512-cAHWIlLF57rxQaJl19AzXw1k0SOM/uLTlx8r2PylHajZ/RRSs7CkCox3oKA6E5zKyfyxk2M64bmsAFZ9RCA0gw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.9.0"
       }
     },
     "@miniflare/r2": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.10.0.tgz",
-      "integrity": "sha512-uC1CCWbwM1t8DdpZgrveg6+CkZLfTq+wUMqs20BC5rCT8u8UyRv6ZVRQ7pTPiswLyt1oYDTXsZJK7tjV0U0zew==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.9.0.tgz",
+      "integrity": "sha512-aMFWxxciAE3YsVok2OLy3A7hP5+2j/NaK7txmadgoe1CA8HYZyNuvv7v6bn8HKM5gWnJdT8sk4yEbMbBQ7Jv/A==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/shared": "2.9.0",
         "undici": "5.9.1"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.10.0.tgz",
-      "integrity": "sha512-oTsHitQdQ1B1kT3G/6n9AEXsMd/sT1D8tLGzc7Xr79ZrxYxwRO0ATF3cdkxk4dUjUqg/RUqvOJV4YjJGyqvctg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.9.0.tgz",
+      "integrity": "sha512-vewP+Fy7Czb261GmB9x/YtQkoDs/QP9B5LbP0YfJ35bI2C2j940eJLm8JP72IHV7ILtWNOqMc3Ure8uAbpf9NQ==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.9.0"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.10.0.tgz",
-      "integrity": "sha512-eGt2cZFE/yo585nT8xINQwdbTotZfeRIh6FUWmZkbva1i5SW0zTiOojr5a95vAGBF3TzwWGsUuzJpLhBB69a/g==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.9.0.tgz",
+      "integrity": "sha512-eodSCGkJYi4Z+Imbx/bNScDfDSt5HOypVSYjbFHj+hA2aNOdkGw6a1b6mzwx49jJD3GadIkonZAKD0S114yWMA==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.10.0.tgz",
-      "integrity": "sha512-GDSweEhJ3nNtStGm6taZGUNytM0QTQ/sjZSedAKyF1/aHRaZUcD9cuKAMgIbSpKfvgGdLMNS7Bhd8jb249TO7g==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.9.0.tgz",
+      "integrity": "sha512-5Ew/Ph0cHDQqKvOlmN70kz+qZW0hdgE9fQBStKLY3vDYhnBEhopbCUChSS+FCcL7WtxVJJVE7iB6J09NQTnQ/A==",
       "dev": true,
       "requires": {
         "@types/better-sqlite3": "^7.6.0",
@@ -12378,144 +10953,86 @@
       }
     },
     "@miniflare/sites": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.10.0.tgz",
-      "integrity": "sha512-1NVAT6+JS2OubL+pOOR5E/6MMddxQHWMi/yIDSumyyfXmj7Sm7n5dE1FvNPetggMP4f8+AjoyT9AYvdd1wkspQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.9.0.tgz",
+      "integrity": "sha512-+tWf7znxSQqXWGzPup8Xqkl8EmLmx+HaLC+UBtWPNnaJZrsjbbVxKwHpmGIdm+wZasEGfQk/82R21gUs9wdZnw==",
       "dev": true,
       "requires": {
-        "@miniflare/kv": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-file": "2.10.0"
+        "@miniflare/kv": "2.9.0",
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/storage-file": "2.9.0"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.10.0.tgz",
-      "integrity": "sha512-K/cRIWiTl4+Z+VO6tl4VfuYXA3NLJgvGPV+BCRYD7uTKuPYHqDMErtD1BI1I7nc3WJhwIXfzJrAR3XXhSKKWQQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.9.0.tgz",
+      "integrity": "sha512-HZHtHfJaLoDzQFddoIMcDGgAJ3/Nee98gwUYusQam7rj9pbEXnWmk54dzjzsDlkQpB/3MBFQNbtN5Bj1NIt0pg==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0"
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/storage-memory": "2.9.0"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.10.0.tgz",
-      "integrity": "sha512-ZATU+qZtJ9yG0umgTrOEUi9SU//YyDb8nYXMgqT4JHODYA3RTz1SyyiQSOOz589upJPdu1LN+0j8W24WGRwwxQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.9.0.tgz",
+      "integrity": "sha512-p2yrr0omQhv6teDbdzhdBKzoQAFmUBMLEx+PtrO7CJHX15ICD08/pFAFAp96IcljNwZZDchU20Z3AcbldMj6Tw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.9.0"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.10.0.tgz",
-      "integrity": "sha512-X9CFYYyszfSYDzs07KhbWC2i08Dpyh3D60fPonYZcoZAfa5h9eATHUdRGvNCdax7awYp4b8bvU8upAI//OPlMg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.9.0.tgz",
+      "integrity": "sha512-Yqz8Q1He/2chebXvmCft8sMamuUiDQ4FIn0bwiF0+GBP2vvGCmy6SejXZY4ZD4REluPqQSis3CLKcIOWlHnIsw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.9.0"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.10.0.tgz",
-      "integrity": "sha512-W+PrapdQqNEEFeD+amENgPQWcETGDp7OEh6JAoSzCRhHA0OoMe8DG0xb5a5+2FjGW/J7FFKsv84wkURpmFT4dQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.9.0.tgz",
+      "integrity": "sha512-Nob9e84m78qeQCka6OQf/JdNOmMkKCkX+i3rg+TYKSSITiMVuyzWp3vz3Ma184lAZiLg44lxBF4ZzENEdi99Kg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/shared": "2.9.0",
         "undici": "5.9.1",
         "ws": "^8.2.2"
       }
     },
     "@multiformats/mafmt": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.0.3.tgz",
-      "integrity": "sha512-DvCQeZJgaC4kE3BLqMuW3gQkNAW14Z7I+yMt30Ze+wkfHkWSp+bICcHGihhtgfzYCumHA/vHlJ9n54mrCcmnvQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.1.0.tgz",
+      "integrity": "sha512-ZGuP26SIbBZutDN/QhqGwuu7b1zTO9DLvG4l3fh15ambPmcwS811MQIyW+d+9Vl7ASheB0qJq0sJrMKsHS3dXA==",
       "requires": {
         "@multiformats/multiaddr": "^11.0.0"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "dns-over-http-resolver": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-          "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-          "requires": {
-            "debug": "^4.3.1",
-            "native-fetch": "^4.0.2",
-            "receptacle": "^1.3.2"
-          }
-        },
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        },
-        "is-ip": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-          "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-          "requires": {
-            "ip-regex": "^5.0.0",
-            "super-regex": "^0.2.0"
-          }
-        },
-        "native-fetch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-          "requires": {}
-        }
       }
     },
     "@multiformats/multiaddr": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.5.0.tgz",
-      "integrity": "sha512-u4qHMyv25iAqCb9twJROoN1M8UDm8bureOCIzwz03fVhwJzV6DpgH1eFz9UAzDn7CpSShQ9SLS5MiC4hJjTfig==",
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
       "requires": {
+        "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
         "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
       },
       "dependencies": {
         "dns-over-http-resolver": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-          "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
+          "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
           "requires": {
             "debug": "^4.3.1",
             "native-fetch": "^4.0.2",
-            "receptacle": "^1.3.2"
-          }
-        },
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        },
-        "is-ip": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-          "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-          "requires": {
-            "ip-regex": "^5.0.0",
-            "super-regex": "^0.2.0"
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
           }
         },
         "native-fetch": {
@@ -12523,6 +11040,14 @@
           "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
           "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
           "requires": {}
+        },
+        "undici": {
+          "version": "5.21.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+          "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
+          "requires": {
+            "busboy": "^1.6.0"
+          }
         }
       }
     },
@@ -12532,71 +11057,35 @@
       "integrity": "sha512-vrWmfFadmix5Ab9l//oRQdQ7O3J5bGJpJRMSm21bHlQB0XV4xtNU6vMZBVXeu3Su79LgflEp37cjTFE3yKf3Hw==",
       "requires": {
         "@multiformats/multiaddr": "^11.0.0"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "dns-over-http-resolver": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-          "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
-          "requires": {
-            "debug": "^4.3.1",
-            "native-fetch": "^4.0.2",
-            "receptacle": "^1.3.2"
-          }
-        },
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        },
-        "is-ip": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-          "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-          "requires": {
-            "ip-regex": "^5.0.0",
-            "super-regex": "^0.2.0"
-          }
-        },
-        "native-fetch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-          "requires": {}
-        }
       }
     },
     "@multiformats/murmur3": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
       "integrity": "sha512-wAPLUErGR8g6Lt+bAZn6218k9YQPym+sjszsXL6o4zfxbA22P+gxWZuuD9wDbwL55xrKO5idpcuQUX7/E3oHcw==",
+      "dev": true,
       "requires": {
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "dev": true
+        }
       }
     },
     "@noble/ed25519": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
-      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw=="
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ=="
     },
     "@noble/secp256k1": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -12804,30 +11293,10 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
-    },
-    "@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
-    },
-    "@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
-    },
-    "@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
-    },
     "@types/better-sqlite3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
-      "integrity": "sha512-RgmaapusqTq6IMAr4McMyAsC6RshYTCjXCnzwVV59WctUxC8bNPyUfT9t5F81lKcU41lLurhjqjoMHfauzfqGg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
+      "integrity": "sha512-YS64N9SNDT/NAvou3QNdzAu3E2om/W/0dhORimtPGLef+zSK5l1vDzfsWb4xgXOgfhtOI5ZDTRxnvRPb22AIVQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -12837,12 +11306,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "devOptional": true
+      "dev": true
     },
     "@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -12878,12 +11348,6 @@
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
       "dev": true
     },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "peer": true
-    },
     "@web-std/blob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.4.tgz",
@@ -12903,50 +11367,21 @@
         "web-streams-polyfill": "^3.1.1"
       }
     },
-    "@web3-storage/fast-unixfs-exporter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/fast-unixfs-exporter/-/fast-unixfs-exporter-0.2.1.tgz",
-      "integrity": "sha512-ylJN3q6/H2IiDaFLXdDSnSx02dFaa7EqSZGCKN20TlSk0ZvBbQ9BXs1q/arik64KZ/OqtLMwBivehMs+dUO7Gg==",
-      "requires": {
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-pb": "^2.0.2",
-        "@multiformats/murmur3": "^1.0.3",
-        "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "interface-blockstore": "^2.0.3",
-        "ipfs-unixfs": "^6.0.0",
-        "it-last": "^1.0.5",
-        "multiformats": "^9.4.2",
-        "p-queue": "^7.3.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "hamt-sharding": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
-          "integrity": "sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA==",
-          "requires": {
-            "sparse-array": "^1.3.1",
-            "uint8arrays": "^3.0.0"
-          }
-        }
-      }
-    },
     "@web3-storage/gateway-lib": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-2.0.2.tgz",
-      "integrity": "sha512-bfmJCE6u+Y7jh09KlRFgZnFLHBKvyCcYlqj0n1OV6JLzkl9xrwnMM4kWscsF5+82kElXdwxeRU0cWntM/Ydkkw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-2.0.3.tgz",
+      "integrity": "sha512-pJhL7ReGAhamkwYS6m+XTpHdSJgVaxnRS820nAHmIK9TrVXXj6ejkEKg6ox364ee/5NLDrx4oyEbxCbDGc373w==",
       "requires": {
-        "@ipld/car": "^4.1.5",
+        "@ipld/car": "^5.1.0",
         "@web3-storage/handlebars": "^1.0.0",
         "bytes": "^3.1.2",
         "chardet": "^1.5.0",
-        "dagula": "^4.1.0",
+        "dagula": "^5.0.0",
         "magic-bytes.js": "^1.0.12",
         "mrmime": "^1.0.1",
-        "multiformats": "^9.9.0",
+        "multiformats": "^11.0.1",
         "timeout-abort-controller": "^3.0.0",
-        "uint8arrays": "^3.1.1"
+        "uint8arrays": "^4.0.3"
       },
       "dependencies": {
         "retimer": {
@@ -13067,9 +11502,10 @@
       }
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -13081,7 +11517,8 @@
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
     },
     "aggregate-error": {
       "version": "4.0.1",
@@ -13114,9 +11551,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -13131,12 +11568,6 @@
         }
       }
     },
-    "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "peer": true
-    },
     "ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -13144,9 +11575,9 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.1.tgz",
-      "integrity": "sha512-qDOv24WjnYuL+wbwHdlsYZFy+cgPtrYw0Tn7GLORicQp9BkQLzrgI3Pm4VyR9ERZ41YTn7KlMPuL1n05WdZvmg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true
     },
     "any-signal": {
@@ -13163,6 +11594,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -13173,15 +11605,11 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -13245,27 +11673,31 @@
       "dev": true
     },
     "atomically": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
-      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.1.tgz",
+      "integrity": "sha512-sxBhVZUFBFhqSAsYMM3X2oaUi2NVDJ8U026FsIusM8gYXls9AYs/eXzgGrufs1Qjpkxi9zunds+75QUFz+m7UQ==",
+      "requires": {
+        "stubborn-fs": "^1.2.4",
+        "when-exit": "^2.0.0"
+      }
     },
     "ava": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-4.3.3.tgz",
-      "integrity": "sha512-9Egq/d9R74ExrWohHeqUlexjDbgZJX5jA1Wq4KCTqc3wIfpGEK79zVy4rBtofJ9YKIxs4PzhJ8BgbW5PlAYe6w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-5.2.0.tgz",
+      "integrity": "sha512-W8yxFXJr/P68JP55eMpQIa6AiXhCX3VeuajM8nolyWNExcMDD6rnIWKTjw0B/+GkFHBIaN6Jd0LtcMThcoqVfg==",
       "dev": true,
       "requires": {
-        "acorn": "^8.7.1",
+        "acorn": "^8.8.1",
         "acorn-walk": "^8.2.0",
-        "ansi-styles": "^6.1.0",
+        "ansi-styles": "^6.2.1",
         "arrgv": "^1.0.2",
         "arrify": "^3.0.0",
         "callsites": "^4.0.0",
         "cbor": "^8.1.0",
-        "chalk": "^5.0.1",
+        "chalk": "^5.2.0",
         "chokidar": "^3.5.3",
         "chunkd": "^2.0.1",
-        "ci-info": "^3.3.1",
+        "ci-info": "^3.7.1",
         "ci-parallel-vars": "^1.0.1",
         "clean-yaml-object": "^0.1.0",
         "cli-truncate": "^3.1.0",
@@ -13274,10 +11706,10 @@
         "concordance": "^5.0.4",
         "currently-unhandled": "^0.4.1",
         "debug": "^4.3.4",
-        "del": "^6.1.1",
-        "emittery": "^0.11.0",
-        "figures": "^4.0.1",
-        "globby": "^13.1.1",
+        "del": "^7.0.0",
+        "emittery": "^1.0.1",
+        "figures": "^5.0.0",
+        "globby": "^13.1.3",
         "ignore-by-default": "^2.1.0",
         "indent-string": "^5.0.0",
         "is-error": "^2.2.2",
@@ -13287,19 +11719,19 @@
         "mem": "^9.0.2",
         "ms": "^2.1.3",
         "p-event": "^5.0.1",
-        "p-map": "^5.4.0",
+        "p-map": "^5.5.0",
         "picomatch": "^2.3.1",
         "pkg-conf": "^4.0.0",
         "plur": "^5.1.0",
-        "pretty-ms": "^7.0.1",
+        "pretty-ms": "^8.0.0",
         "resolve-cwd": "^3.0.0",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.5",
+        "stack-utils": "^2.0.6",
         "strip-ansi": "^7.0.1",
         "supertap": "^3.0.1",
-        "temp-dir": "^2.0.0",
-        "write-file-atomic": "^4.0.1",
-        "yargs": "^17.5.1"
+        "temp-dir": "^3.0.0",
+        "write-file-atomic": "^5.0.0",
+        "yargs": "^17.6.2"
       }
     },
     "available-typed-arrays": {
@@ -13311,7 +11743,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -13319,10 +11752,20 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
     },
     "bl": {
       "version": "5.0.0",
@@ -13358,6 +11801,14 @@
         "it-filter": "^1.0.2",
         "it-take": "^1.0.1",
         "multiformats": "^9.4.7"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "dev": true
+        }
       }
     },
     "blueimp-md5": {
@@ -13370,6 +11821,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -13379,6 +11831,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -13388,12 +11841,6 @@
       "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
       "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==",
       "dev": true
-    },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "peer": true
     },
     "buffer": {
       "version": "6.0.3",
@@ -13408,7 +11855,8 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "builtins": {
       "version": "5.0.1",
@@ -13423,7 +11871,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
       "requires": {
         "streamsearch": "^1.1.0"
       }
@@ -13518,18 +11965,33 @@
             "cborg": "^1.5.4",
             "multiformats": "^9.5.4"
           }
+        },
+        "@ipld/dag-pb": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+          "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^9.5.4"
+          }
+        },
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "dev": true
         }
       }
     },
     "cardex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-1.0.0.tgz",
-      "integrity": "sha512-Xirpn7ZPeNEIZ7spEOH7+RnFdZP2yVGMGR0Sj3ON4eEoCFZjzsnFXCYszTk39wWekst3GLN1E/yb2vKATQTMMg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-1.0.1.tgz",
+      "integrity": "sha512-qtEBmfCPU9alMle+ZEJuBCO9OOPQmgowRzYcumxX0mI9aU0/GEvI6riZF6P2ouT4JH6yM3aYbDaqcoVuV3UVQw==",
       "requires": {
-        "@ipld/car": "^4.1.5",
-        "multiformats": "^9.6.5",
+        "@ipld/car": "^5.1.0",
+        "multiformats": "^11.0.2",
         "sade": "^1.8.1",
-        "uint8arrays": "^3.0.0",
+        "uint8arrays": "^4.0.3",
         "varint": "^6.0.0"
       }
     },
@@ -13543,14 +12005,14 @@
       }
     },
     "cborg": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.5.tgz",
-      "integrity": "sha512-fLBv8wmqtlXqy1Yu+pHzevAIkW6k2K0ZtMujNzWphLsA34vzzg9BHn+5GmZqOJkSA9V7EMKsWrf6K976c1QMjQ=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
+      "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ=="
     },
     "chalk": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "dev": true
     },
     "chardet": {
@@ -13562,6 +12024,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -13580,9 +12043,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
-      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
       "dev": true
     },
     "ci-parallel-vars": {
@@ -13667,14 +12130,6 @@
         }
       }
     },
-    "clone-regexp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
-      "integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
-      "requires": {
-        "is-regexp": "^3.0.0"
-      }
-    },
     "code-excerpt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
@@ -13708,7 +12163,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "concordance": {
       "version": "5.0.4",
@@ -13727,26 +12183,24 @@
       }
     },
     "conf": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
-      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-11.0.1.tgz",
+      "integrity": "sha512-WlLiQboEjKx0bYx2IIRGedBgNjLAxtwPaCSnsjWPST5xR0DB4q8lcsO/bEH9ZRYNcj63Y9vj/JG/5Fg6uWzI0Q==",
       "requires": {
-        "ajv": "^8.6.3",
+        "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
-        "atomically": "^1.7.0",
-        "debounce-fn": "^4.0.0",
-        "dot-prop": "^6.0.1",
-        "env-paths": "^2.2.1",
-        "json-schema-typed": "^7.0.3",
-        "onetime": "^5.1.2",
-        "pkg-up": "^3.1.0",
-        "semver": "^7.3.5"
+        "atomically": "^2.0.0",
+        "debounce-fn": "^5.1.2",
+        "dot-prop": "^7.2.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.3.8"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -13758,26 +12212,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-        },
-        "onetime": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
         }
       }
-    },
-    "convert-hrtime": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
-      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg=="
     },
     "convert-to-spaces": {
       "version": "2.0.1",
@@ -13790,11 +12226,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cron-schedule": {
       "version": "3.0.6",
@@ -13822,28 +12253,31 @@
       }
     },
     "dagula": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-4.1.1.tgz",
-      "integrity": "sha512-sBkyCB7z9wacSiXoP9Gmn7cfovTKenlK0Z8W3pSzS+S+EMfkwSwTrPcAHtnY6EqY4OCi2WTu74PZa9vXEl5WDw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/dagula/-/dagula-5.0.0.tgz",
+      "integrity": "sha512-cGlHQuIiNNyxP/ehMFuKCw59FMn+1zC+ESGmMuHc552bIIxLChfNwghY0bRGe0JyyS2pCi/5E+QcDTEfpxcxbw==",
       "requires": {
-        "@chainsafe/libp2p-noise": "^7.0.1",
-        "@ipld/car": "^4.1.3",
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-json": "^8.0.10",
-        "@ipld/dag-pb": "^2.1.17",
-        "@libp2p/interfaces": "^2.0.4",
-        "@libp2p/mplex": "^1.2.1",
-        "@libp2p/tcp": "^3.0.2",
-        "@libp2p/websockets": "^3.0.1",
-        "@multiformats/multiaddr": "^10.3.3",
-        "@web3-storage/fast-unixfs-exporter": "^0.2.1",
+        "@chainsafe/libp2p-noise": "^11.0.0",
+        "@ipld/car": "^5.0.3",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/interface-connection": "^3.0.8",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-registrar": "^2.0.8",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/mplex": "^7.1.1",
+        "@libp2p/tcp": "^6.0.9",
+        "@libp2p/websockets": "^5.0.3",
+        "@multiformats/multiaddr": "^11.3.0",
         "archy": "^1.0.0",
-        "conf": "^10.1.2",
+        "conf": "^11.0.1",
         "debug": "^4.3.4",
-        "it-length-prefixed": "^7.0.1",
+        "ipfs-unixfs-exporter": "^12.0.2",
+        "it-length-prefixed": "^8.0.4",
         "it-pipe": "^2.0.3",
-        "libp2p": "^0.37.3",
-        "multiformats": "^9.7.0",
+        "libp2p": "^0.42.2",
+        "multiformats": "^11.0.1",
         "p-defer": "^4.0.0",
         "protobufjs": "^7.0.0",
         "sade": "^1.8.1",
@@ -13861,11 +12295,6 @@
             "it-stream-types": "^1.0.3"
           }
         },
-        "it-pushable": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-          "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-        },
         "retimer": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
@@ -13882,30 +12311,86 @@
       }
     },
     "datastore-core": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-7.0.3.tgz",
-      "integrity": "sha512-DmPsUux63daOfCszxLkcp6LjdJ0k/BQNhIMtoAi5mbraYQnEQkFtKORmTu6XmDX6ujbtaBkeuJAiCBNI7MZklw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-8.0.4.tgz",
+      "integrity": "sha512-oBA6a024NFXJOTu+w9nLAimfy4wCYUhdE/5XQGtdKt1BmCVtPYW10GORvVT3pdZBcse6k/mVcBl+hjkXIlm65A==",
       "requires": {
-        "debug": "^4.1.1",
+        "@libp2p/logger": "^2.0.0",
         "err-code": "^3.0.1",
-        "interface-datastore": "^6.0.2",
-        "it-drain": "^1.0.4",
-        "it-filter": "^1.0.2",
-        "it-map": "^1.0.5",
-        "it-merge": "^1.0.1",
-        "it-pipe": "^1.1.0",
-        "it-pushable": "^1.4.2",
-        "it-take": "^1.0.1",
-        "uint8arrays": "^3.0.0"
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-drain": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-merge": "^2.0.0",
+        "it-pipe": "^2.0.3",
+        "it-pushable": "^3.0.0",
+        "it-take": "^2.0.0",
+        "uint8arrays": "^4.0.2"
       },
       "dependencies": {
-        "it-pushable": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-1.4.2.tgz",
-          "integrity": "sha512-vVPu0CGRsTI8eCfhMknA7KIBqqGFolbRx+1mbQ6XuZ7YCz995Qj7L4XUviwClFunisDq96FdxzF5FnAbw15afg==",
+        "interface-datastore": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+          "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
           "requires": {
-            "fast-fifo": "^1.0.0"
+            "interface-store": "^3.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
           }
+        },
+        "interface-store": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+          "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
+        },
+        "it-all": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+          "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA=="
+        },
+        "it-drain": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.1.tgz",
+          "integrity": "sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ=="
+        },
+        "it-filter": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+          "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg=="
+        },
+        "it-map": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+          "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ=="
+        },
+        "it-merge": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+          "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
+          "requires": {
+            "it-pushable": "^3.1.0"
+          }
+        },
+        "it-pipe": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+          "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
+          "requires": {
+            "it-merge": "^2.0.0",
+            "it-pushable": "^3.1.0",
+            "it-stream-types": "^1.0.3"
+          }
+        },
+        "it-take": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.1.tgz",
+          "integrity": "sha512-DL7kpZNjuoeSTnB9dMAJ0Z3m2T29LRRAU+HIgkiQM+1jH3m8l9e/1xpWs8JHTlbKivbqSFrQMTc8KVcaQNmsaA=="
+        },
+        "nanoid": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+          "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww=="
         }
       }
     },
@@ -13919,18 +12404,11 @@
       }
     },
     "debounce-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
-      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-5.1.2.tgz",
+      "integrity": "sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==",
       "requires": {
-        "mimic-fn": "^3.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
-        }
+        "mimic-fn": "^4.0.0"
       }
     },
     "debug": {
@@ -14051,73 +12529,28 @@
       }
     },
     "del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-7.0.0.tgz",
+      "integrity": "sha512-tQbV/4u5WVB8HMJr08pgw0b6nG4RGt/tj+7Numvq+zqcvUFeMaIWWOUFltiU+6go8BSO2/ogsB4EasDaj0y68Q==",
       "dev": true,
       "requires": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
+        "globby": "^13.1.2",
+        "graceful-fs": "^4.2.10",
+        "is-glob": "^4.0.3",
+        "is-path-cwd": "^3.0.0",
+        "is-path-inside": "^4.0.0",
+        "p-map": "^5.5.0",
         "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
+        "slash": "^4.0.0"
       },
       "dependencies": {
-        "aggregate-error": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-          "dev": true,
-          "requires": {
-            "clean-stack": "^2.0.0",
-            "indent-string": "^4.0.0"
-          }
-        },
-        "clean-stack": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-          "dev": true
-        },
-        "globby": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.2.9",
-            "ignore": "^5.2.0",
-            "merge2": "^1.4.1",
-            "slash": "^3.0.0"
-          }
-        },
-        "indent-string": {
+        "slash": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
           "dev": true
-        },
-        "p-map": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
         }
       }
-    },
-    "diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "peer": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -14149,11 +12582,18 @@
       }
     },
     "dot-prop": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-7.2.0.tgz",
+      "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
       "requires": {
-        "is-obj": "^2.0.0"
+        "type-fest": "^2.11.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "dotenv": {
@@ -14178,9 +12618,9 @@
       }
     },
     "emittery": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.11.0.tgz",
-      "integrity": "sha512-S/7tzL6v5i+4iJd627Nhv9cLFIo5weAIlGccqJFpnBoDB8U1TF2k5tez4J/QNuxyyhWuFqHg1L84Kd3m7iXg6g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.1.tgz",
+      "integrity": "sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -14199,9 +12639,9 @@
       }
     },
     "env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="
     },
     "err-code": {
       "version": "3.0.1",
@@ -14270,174 +12710,34 @@
       }
     },
     "esbuild": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.10.tgz",
-      "integrity": "sha512-N7wBhfJ/E5fzn/SpNgX+oW2RLRjwaL8Y0ezqNqhjD6w0H2p0rDuEz2FKZqpqLnO8DCaWumKe8dsC/ljvVSSxng==",
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.11.tgz",
+      "integrity": "sha512-pAMImyokbWDtnA/ufPxjQg0fYo2DDuzAlqwnDvbXqHLphe+m80eF++perYKVm8LeTuj2zUuFXC+xgSVxyoHUdg==",
       "dev": true,
       "requires": {
-        "@esbuild/android-arm": "0.15.10",
-        "@esbuild/linux-loong64": "0.15.10",
-        "esbuild-android-64": "0.15.10",
-        "esbuild-android-arm64": "0.15.10",
-        "esbuild-darwin-64": "0.15.10",
-        "esbuild-darwin-arm64": "0.15.10",
-        "esbuild-freebsd-64": "0.15.10",
-        "esbuild-freebsd-arm64": "0.15.10",
-        "esbuild-linux-32": "0.15.10",
-        "esbuild-linux-64": "0.15.10",
-        "esbuild-linux-arm": "0.15.10",
-        "esbuild-linux-arm64": "0.15.10",
-        "esbuild-linux-mips64le": "0.15.10",
-        "esbuild-linux-ppc64le": "0.15.10",
-        "esbuild-linux-riscv64": "0.15.10",
-        "esbuild-linux-s390x": "0.15.10",
-        "esbuild-netbsd-64": "0.15.10",
-        "esbuild-openbsd-64": "0.15.10",
-        "esbuild-sunos-64": "0.15.10",
-        "esbuild-windows-32": "0.15.10",
-        "esbuild-windows-64": "0.15.10",
-        "esbuild-windows-arm64": "0.15.10"
+        "@esbuild/android-arm": "0.17.11",
+        "@esbuild/android-arm64": "0.17.11",
+        "@esbuild/android-x64": "0.17.11",
+        "@esbuild/darwin-arm64": "0.17.11",
+        "@esbuild/darwin-x64": "0.17.11",
+        "@esbuild/freebsd-arm64": "0.17.11",
+        "@esbuild/freebsd-x64": "0.17.11",
+        "@esbuild/linux-arm": "0.17.11",
+        "@esbuild/linux-arm64": "0.17.11",
+        "@esbuild/linux-ia32": "0.17.11",
+        "@esbuild/linux-loong64": "0.17.11",
+        "@esbuild/linux-mips64el": "0.17.11",
+        "@esbuild/linux-ppc64": "0.17.11",
+        "@esbuild/linux-riscv64": "0.17.11",
+        "@esbuild/linux-s390x": "0.17.11",
+        "@esbuild/linux-x64": "0.17.11",
+        "@esbuild/netbsd-x64": "0.17.11",
+        "@esbuild/openbsd-x64": "0.17.11",
+        "@esbuild/sunos-x64": "0.17.11",
+        "@esbuild/win32-arm64": "0.17.11",
+        "@esbuild/win32-ia32": "0.17.11",
+        "@esbuild/win32-x64": "0.17.11"
       }
-    },
-    "esbuild-android-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.10.tgz",
-      "integrity": "sha512-UI7krF8OYO1N7JYTgLT9ML5j4+45ra3amLZKx7LO3lmLt1Ibn8t3aZbX5Pu4BjWiqDuJ3m/hsvhPhK/5Y/YpnA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-android-arm64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.10.tgz",
-      "integrity": "sha512-EOt55D6xBk5O05AK8brXUbZmoFj4chM8u3riGflLa6ziEoVvNjRdD7Cnp82NHQGfSHgYR06XsPI8/sMuA/cUwg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.10.tgz",
-      "integrity": "sha512-hbDJugTicqIm+WKZgp208d7FcXcaK8j2c0l+fqSJ3d2AzQAfjEYDRM3Z2oMeqSJ9uFxyj/muSACLdix7oTstRA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-arm64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.10.tgz",
-      "integrity": "sha512-M1t5+Kj4IgSbYmunf2BB6EKLkWUq+XlqaFRiGOk8bmBapu9bCDrxjf4kUnWn59Dka3I27EiuHBKd1rSO4osLFQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.10.tgz",
-      "integrity": "sha512-KMBFMa7C8oc97nqDdoZwtDBX7gfpolkk6Bcmj6YFMrtCMVgoU/x2DI1p74DmYl7CSS6Ppa3xgemrLrr5IjIn0w==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-arm64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.10.tgz",
-      "integrity": "sha512-m2KNbuCX13yQqLlbSojFMHpewbn8wW5uDS6DxRpmaZKzyq8Dbsku6hHvh2U+BcLwWY4mpgXzFUoENEf7IcioGg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-32": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.10.tgz",
-      "integrity": "sha512-guXrwSYFAvNkuQ39FNeV4sNkNms1bLlA5vF1H0cazZBOLdLFIny6BhT+TUbK/hdByMQhtWQ5jI9VAmPKbVPu1w==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.10.tgz",
-      "integrity": "sha512-jd8XfaSJeucMpD63YNMO1JCrdJhckHWcMv6O233bL4l6ogQKQOxBYSRP/XLWP+6kVTu0obXovuckJDcA0DKtQA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.10.tgz",
-      "integrity": "sha512-6N8vThLL/Lysy9y4Ex8XoLQAlbZKUyExCWyayGi2KgTBelKpPgj6RZnUaKri0dHNPGgReJriKVU6+KDGQwn10A==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.10.tgz",
-      "integrity": "sha512-GByBi4fgkvZFTHFDYNftu1DQ1GzR23jws0oWyCfhnI7eMOe+wgwWrc78dbNk709Ivdr/evefm2PJiUBMiusS1A==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-mips64le": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.10.tgz",
-      "integrity": "sha512-BxP+LbaGVGIdQNJUNF7qpYjEGWb0YyHVSKqYKrn+pTwH/SiHUxFyJYSP3pqkku61olQiSBnSmWZ+YUpj78Tw7Q==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-ppc64le": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.10.tgz",
-      "integrity": "sha512-LoSQCd6498PmninNgqd/BR7z3Bsk/mabImBWuQ4wQgmQEeanzWd5BQU2aNi9mBURCLgyheuZS6Xhrw5luw3OkQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-riscv64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.10.tgz",
-      "integrity": "sha512-Lrl9Cr2YROvPV4wmZ1/g48httE8z/5SCiXIyebiB5N8VT7pX3t6meI7TQVHw/wQpqP/AF4SksDuFImPTM7Z32Q==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-s390x": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.10.tgz",
-      "integrity": "sha512-ReP+6q3eLVVP2lpRrvl5EodKX7EZ1bS1/z5j6hsluAlZP5aHhk6ghT6Cq3IANvvDdscMMCB4QEbI+AjtvoOFpA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-netbsd-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.10.tgz",
-      "integrity": "sha512-iGDYtJCMCqldMskQ4eIV+QSS/CuT7xyy9i2/FjpKvxAuCzrESZXiA1L64YNj6/afuzfBe9i8m/uDkFHy257hTw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-openbsd-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.10.tgz",
-      "integrity": "sha512-ftMMIwHWrnrYnvuJQRJs/Smlcb28F9ICGde/P3FUTCgDDM0N7WA0o9uOR38f5Xe2/OhNCgkjNeb7QeaE3cyWkQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-sunos-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.10.tgz",
-      "integrity": "sha512-mf7hBL9Uo2gcy2r3rUFMjVpTaGpFJJE5QTDDqUFf1632FxteYANffDZmKbqX0PfeQ2XjUDE604IcE7OJeoHiyg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-32": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.10.tgz",
-      "integrity": "sha512-ttFVo+Cg8b5+qHmZHbEc8Vl17kCleHhLzgT8X04y8zudEApo0PxPg9Mz8Z2cKH1bCYlve1XL8LkyXGFjtUYeGg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.10.tgz",
-      "integrity": "sha512-2H0gdsyHi5x+8lbng3hLbxDWR7mKHWh5BXZGKVG830KUmXOOWFE2YKJ4tHRkejRduOGDrBvHBriYsGtmTv3ntA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-arm64": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.10.tgz",
-      "integrity": "sha512-S+th4F+F8VLsHLR0zrUcG+Et4hx0RKgK1eyHc08kztmLOES8BWwMiaGdoW9hiXuzznXQ0I/Fg904MNbr11Nktw==",
-      "dev": true,
-      "optional": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -15006,9 +13306,9 @@
       }
     },
     "figures": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-4.0.1.tgz",
-      "integrity": "sha512-rElJwkA/xS04Vfg+CaZodpso7VqBknOYbzi6I76hI4X80RUjkSxO2oAyPmGbuXUppywjqndOrQDl817hDnI++w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^5.0.0",
@@ -15052,6 +13352,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -15073,12 +13374,6 @@
           "dev": true
         }
       }
-    },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "peer": true
     },
     "flat-cache": {
       "version": "3.0.4",
@@ -15113,12 +13408,14 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -15126,11 +13423,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "function-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
-      "integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg=="
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -15210,6 +13502,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -15232,9 +13525,9 @@
       }
     },
     "globby": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
-      "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
       "dev": true,
       "requires": {
         "dir-glob": "^3.0.1",
@@ -15264,11 +13557,14 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "peer": true
+    "hamt-sharding": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.2.tgz",
+      "integrity": "sha512-f0DzBD2tSmLFdFsLAvOflIBqFPjerbA7BfmwO8mVho/5hXwgyyYhv+ijIzidQf/DpDX3bRjAQvhGoBFj+DBvPw==",
+      "requires": {
+        "sparse-array": "^1.3.1",
+        "uint8arrays": "^4.0.2"
+      }
     },
     "hard-rejection": {
       "version": "2.1.0",
@@ -15326,12 +13622,6 @@
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
       "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "peer": true
-    },
     "hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -15348,9 +13638,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "human-signals": {
@@ -15429,6 +13719,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -15437,31 +13728,60 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "interface-blockstore": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.3.tgz",
       "integrity": "sha512-OwVUnlNcx7H5HloK0Myv6c/C1q9cNG11HX6afdeU6q6kbuNj8jKCwVnmJHhC94LZaJ+9hvVOk4IUstb3Esg81w==",
+      "dev": true,
       "requires": {
         "interface-store": "^2.0.2",
         "multiformats": "^9.0.4"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "dev": true
+        }
       }
     },
     "interface-datastore": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
       "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "dev": true,
       "requires": {
         "interface-store": "^2.0.2",
         "nanoid": "^3.0.2",
         "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "dev": true
+        },
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        }
       }
     },
     "interface-store": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
-      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg==",
+      "dev": true
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -15477,7 +13797,8 @@
     "ip-regex": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "2.0.1",
@@ -15485,9 +13806,9 @@
       "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
     },
     "ipfs-car": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.8.1.tgz",
-      "integrity": "sha512-ntRXBK5ZTaXgxAkSLvC6mXupJcwxxX9tusKoOJR+SRZWGfA+5j+WeJa5gCgdHEsGixIX93rZH8DSzdUUTYjNJg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.9.2.tgz",
+      "integrity": "sha512-OUKgQqCN9C16eyu9OSOXe2CyRUL/jemWDODfALihvwRHfLLU6tKQVb8rhjhheWhQ1InlFBMgfIiLNxGpUSqOXA==",
       "dev": true,
       "requires": {
         "@ipld/car": "^3.2.3",
@@ -15524,6 +13845,25 @@
             "varint": "^6.0.0"
           }
         },
+        "@ipld/dag-cbor": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+          "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+          "dev": true,
+          "requires": {
+            "cborg": "^1.6.0",
+            "multiformats": "^9.5.4"
+          }
+        },
+        "@ipld/dag-pb": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+          "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^9.5.4"
+          }
+        },
         "hamt-sharding": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
@@ -15552,11 +13892,26 @@
             "uint8arrays": "^3.0.0"
           }
         },
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "dev": true
+        },
         "streaming-iterables": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.2.0.tgz",
           "integrity": "sha512-3AYC8oB60WyD1ic7uHmN/vm2oRGzRnQ3XFBl/bFMDi1q1+nc5/vjMmiE4vroIya3jG59t87VpyAj/iXYxyw9AA==",
           "dev": true
+        },
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
         }
       }
     },
@@ -15569,6 +13924,14 @@
         "interface-datastore": "^6.0.2",
         "multiaddr": "^10.0.0",
         "multiformats": "^9.4.13"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "dev": true
+        }
       }
     },
     "ipfs-core-utils": {
@@ -15597,12 +13960,30 @@
         "parse-duration": "^1.0.0",
         "timeout-abort-controller": "^1.1.1",
         "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "dev": true
+        },
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        }
       }
     },
     "ipfs-unixfs": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
       "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+      "dev": true,
       "requires": {
         "err-code": "^3.0.1",
         "protobufjs": "^6.10.2"
@@ -15611,12 +13992,14 @@
         "long": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+          "dev": true
         },
         "protobufjs": {
           "version": "6.11.3",
           "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
           "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+          "dev": true,
           "requires": {
             "@protobufjs/aspromise": "^1.1.2",
             "@protobufjs/base64": "^1.1.2",
@@ -15631,6 +14014,106 @@
             "@types/long": "^4.0.1",
             "@types/node": ">=13.7.0",
             "long": "^4.0.0"
+          }
+        }
+      }
+    },
+    "ipfs-unixfs-exporter": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-12.0.2.tgz",
+      "integrity": "sha512-bt93YHQplKWFPqZCsAZLBbHG11dNuJtyvnZakcKmbYUC8iPyy0dfHPcTEB8Rz6JL7lSAJp7M4g4dCdv2U6sBGw==",
+      "requires": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@multiformats/murmur3": "^2.0.0",
+        "err-code": "^3.0.1",
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^4.0.1",
+        "ipfs-unixfs": "^11.0.0",
+        "it-filter": "^2.0.0",
+        "it-last": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^2.0.4",
+        "it-pushable": "^3.1.0",
+        "multiformats": "^11.0.0",
+        "p-queue": "^7.3.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "@multiformats/murmur3": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.3.tgz",
+          "integrity": "sha512-YvLK1IrLnRckPsvXhOkZjaIGNonsEdD1dL3NPSaLilV/WjVYeBgnNZXTUsaPzFXGrIFM7motx+yCmmqzXO6gtQ==",
+          "requires": {
+            "multiformats": "^11.0.0",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "interface-blockstore": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-4.0.1.tgz",
+          "integrity": "sha512-ROWKGJls7vLeFaQtI3hZVCJOkUoZ05xAi2t2qysM4d7dwVKrfm5jUOqWh8JgLL7Iup3XqJ0mKXXZuwJ3s03RSw==",
+          "requires": {
+            "interface-store": "^3.0.0",
+            "multiformats": "^11.0.0"
+          }
+        },
+        "interface-store": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+          "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
+        },
+        "ipfs-unixfs": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.0.tgz",
+          "integrity": "sha512-ZHTTzP5yuimLTln+8VKc3IcsO4ObS6/U8eZ3CA69s1DdW9uBfyjEo6/GTZA80yokHVGWvmCl1S28zmJ5JskP4Q==",
+          "requires": {
+            "err-code": "^3.0.1",
+            "protons-runtime": "^5.0.0",
+            "uint8arraylist": "^2.4.3"
+          }
+        },
+        "it-filter": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+          "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg=="
+        },
+        "it-last": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.1.tgz",
+          "integrity": "sha512-uVMedYW0wa2Cx0TAmcOCLbfuLLII7+vyURmhKa8Zovpd+aBTMsmINtsta2n364wJ5qsEDBH+akY1sUtAkaYBlg=="
+        },
+        "it-map": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+          "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ=="
+        },
+        "it-merge": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+          "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
+          "requires": {
+            "it-pushable": "^3.1.0"
+          }
+        },
+        "it-pipe": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+          "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
+          "requires": {
+            "it-merge": "^2.0.0",
+            "it-pushable": "^3.1.0",
+            "it-stream-types": "^1.0.3"
+          }
+        },
+        "protons-runtime": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+          "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+          "requires": {
+            "protobufjs": "^7.0.0",
+            "uint8arraylist": "^2.4.3"
           }
         }
       }
@@ -15658,6 +14141,15 @@
         "uint8arrays": "^3.0.0"
       },
       "dependencies": {
+        "@ipld/dag-pb": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+          "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^9.5.4"
+          }
+        },
         "hamt-sharding": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
@@ -15666,6 +14158,21 @@
           "requires": {
             "sparse-array": "^1.3.1",
             "uint8arrays": "^3.0.0"
+          }
+        },
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "dev": true
+        },
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^9.4.2"
           }
         }
       }
@@ -15735,6 +14242,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -15787,7 +14295,8 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "4.0.0",
@@ -15808,6 +14317,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -15816,6 +14326,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
       "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dev": true,
       "requires": {
         "ip-regex": "^4.0.0"
       }
@@ -15834,7 +14345,8 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -15845,21 +14357,16 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
-    },
     "is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
+      "integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==",
       "dev": true
     },
     "is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
       "dev": true
     },
     "is-plain-obj": {
@@ -15888,11 +14395,6 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-regexp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
@@ -15960,15 +14462,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "iso-random-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.2.tgz",
-      "integrity": "sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==",
-      "requires": {
-        "events": "^3.3.0",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "iso-url": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
@@ -15977,7 +14470,8 @@
     "it-all": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+      "dev": true
     },
     "it-batch": {
       "version": "1.0.9",
@@ -15985,15 +14479,27 @@
       "integrity": "sha512-7Q7HXewMhNFltTsAMdSz6luNhyhkhEtGGbYek/8Xb/GiqYMtwUmopE1ocPSiJKKp3rM4Dt045sNFoUu+KZGNyA==",
       "dev": true
     },
+    "it-batched-bytes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-1.0.1.tgz",
+      "integrity": "sha512-ptBiZ0Mh3kJYySpG0pCS7JgvWhaAW1fGfKDVFtNIuNTA+bpSlXINvD5H3b14ZlJbnJFzFzRSCSZ10E1nH4z/WQ==",
+      "requires": {
+        "it-stream-types": "^1.0.4",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.1"
+      }
+    },
     "it-drain": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.5.tgz",
-      "integrity": "sha512-r/GjkiW1bZswC04TNmUnLxa6uovme7KKwPhc+cb1hHU65E3AByypHH6Pm91WHuvqfFsm+9ws0kPtDBV3/8vmIg=="
+      "integrity": "sha512-r/GjkiW1bZswC04TNmUnLxa6uovme7KKwPhc+cb1hHU65E3AByypHH6Pm91WHuvqfFsm+9ws0kPtDBV3/8vmIg==",
+      "dev": true
     },
     "it-filter": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.3.tgz",
-      "integrity": "sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w=="
+      "integrity": "sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w==",
+      "dev": true
     },
     "it-first": {
       "version": "1.0.7",
@@ -16001,9 +14507,9 @@
       "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
     },
     "it-foreach": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-0.1.1.tgz",
-      "integrity": "sha512-ZLxL651N5w5SL/EIIcrXELgYrrkuEKj/TErG93C4lr6lNZziKsf338ljSG85PjQfu7Frg/1wESl5pLrPSFXI9g=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-1.0.1.tgz",
+      "integrity": "sha512-eaVFhKxU+uwPs7+DKYxjuL6pj6c50/MBlAH+XPMgPWRRVIChVoyEIsdUQkkC0Ad6oTUmJbKRTnJxEY6o2aIs7A=="
     },
     "it-glob": {
       "version": "1.0.2",
@@ -16025,45 +14531,31 @@
         "it-stream-types": "^1.0.4",
         "p-defer": "^4.0.0",
         "uint8arraylist": "^2.0.0"
-      },
-      "dependencies": {
-        "it-pushable": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-          "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-        }
       }
     },
     "it-last": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
-      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q==",
+      "dev": true
     },
     "it-length-prefixed": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-7.0.1.tgz",
-      "integrity": "sha512-UozKoT0zZPUa0LO9OSq5KaLKPn83U7Vsy/BNAN0TUXfTI/pKrOz6RuyTSOok6NDad12FZsShBGnl9DKlfDT95g==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.4.tgz",
+      "integrity": "sha512-5OJ1lxH+IaqJB7lxe8IAIwt9UfSfsmjKJoAI/RO9djYoBDt1Jfy9PeVHUmOfqhqyu/4kJvWBFAJUaG1HhLQ12A==",
       "requires": {
         "err-code": "^3.0.1",
         "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.2.0",
-        "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
-          }
-        }
+        "uint8-varint": "^1.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
       }
     },
     "it-map": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
-      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ==",
+      "dev": true
     },
     "it-merge": {
       "version": "1.0.4",
@@ -16084,11 +14576,19 @@
       }
     },
     "it-pair": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.3.tgz",
-      "integrity": "sha512-heCgsbYscFCQY5YvltlGT9tjgLGYo7NxPEoJyl55X4BD2KOXpTyuwOhPLWhi9Io0y6+4ZUXCkyaQXIB6Y8xhRw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.4.tgz",
+      "integrity": "sha512-S3y3mTJ3muuxcHBGcIzNONofAN+G3iAgmSjS78qARkRWI2ImJXybjj0h52uSW+isgrJqIx2iFB/T8ZEBc8kDSw==",
       "requires": {
         "it-stream-types": "^1.0.3",
+        "p-defer": "^4.0.0"
+      }
+    },
+    "it-parallel": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.1.tgz",
+      "integrity": "sha512-Wq9DcoLrFV9n5YzWC4BlOQT+v5qgir/iIO/CJ1eV0T5t9rcCZFPKOZB3E8wIhZ5ruSApc2w7UKrbn5iENqew5A==",
+      "requires": {
         "p-defer": "^4.0.0"
       }
     },
@@ -16102,28 +14602,14 @@
       }
     },
     "it-pb-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-2.0.2.tgz",
-      "integrity": "sha512-FR1FM9W71wMTZlAij1Pq4PKNcfVb0TGhUTpNQ3tv0LMV/pJ5cDh4g3jW7jhwB+kHtr7PywD1CybBHaT8iAVpKg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-2.0.4.tgz",
+      "integrity": "sha512-p0chBIT3HrZt3hIqvBEi+NgZxxT25MTJ362nKoHmzA/k/WsUPPbeSz7Ad+wRcGxZn2O5JEXCS5lOGRjSDSnlNg==",
       "requires": {
         "it-handshake": "^4.1.2",
         "it-length-prefixed": "^8.0.2",
         "it-stream-types": "^1.0.4",
         "uint8arraylist": "^2.0.0"
-      },
-      "dependencies": {
-        "it-length-prefixed": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-          "integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-          "requires": {
-            "err-code": "^3.0.1",
-            "it-stream-types": "^1.0.4",
-            "uint8-varint": "^1.0.1",
-            "uint8arraylist": "^2.0.0",
-            "uint8arrays": "^3.0.0"
-          }
-        }
       }
     },
     "it-peekable": {
@@ -16135,28 +14621,36 @@
     "it-pipe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
-      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg==",
+      "dev": true
     },
     "it-pushable": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-2.0.2.tgz",
-      "integrity": "sha512-f/n6HqXGDbHvuMR/3UN+S6W4y/bS1Pxg6Lb0oVc5dbflxy5f3NKkizKs86B8vzqHnB9hm1YpE0pgcEvI3FKDQw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
+      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ=="
     },
     "it-reader": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.1.tgz",
-      "integrity": "sha512-C+YRk3OTufbKSJMNEonfEw+9F38llmwwZvqhkjb0xIgob7l4L3p01Yt43+bHRI8SSppAOgk5AKLqas7ea0UTAw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.2.tgz",
+      "integrity": "sha512-rQdVyml+r/2v8PQsPfJgf626tAkbA7NW1EF6zuucT2Ryy1U6YJtSuCJL8fKuDOyiR/mLzbfP0QQJlSeeoLph2A==",
       "requires": {
         "it-stream-types": "^1.0.4",
         "uint8arraylist": "^2.0.0"
       }
     },
     "it-sort": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-1.0.1.tgz",
-      "integrity": "sha512-c+C48cP7XMMebB9irLrJs2EmpLILId8NYSojqAqN8etE8ienx0azBgaKvZHYH1DkerqIul0Fl2FqISu2BZgTEQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-2.0.1.tgz",
+      "integrity": "sha512-9f4jKOTHfxc/FJpg/wwuQ+j+88i+sfNGKsu2HukAKymm71/XDnBFtOAOzaimko3YIhmn/ERwnfEKrsYLykxw9A==",
       "requires": {
-        "it-all": "^1.0.6"
+        "it-all": "^2.0.0"
+      },
+      "dependencies": {
+        "it-all": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+          "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA=="
+        }
       }
     },
     "it-stream-types": {
@@ -16167,7 +14661,8 @@
     "it-take": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.2.tgz",
-      "integrity": "sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw=="
+      "integrity": "sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw==",
+      "dev": true
     },
     "it-to-stream": {
       "version": "1.0.0",
@@ -16192,14 +14687,14 @@
       }
     },
     "it-ws": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.2.tgz",
-      "integrity": "sha512-beq/nBWuKm2Ds4nYSfPuZRF0USVZJhsIvuUH3kRE5QdaCzivDK7zyeewDgsNBSPr6hPgF5dyPP5NXcXhUcb9QQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.6.tgz",
+      "integrity": "sha512-TEEJQaGtkxgP/nGVq8dq48nPT85Afu8kwwvtDFLj4rQLWRhZcb26RWdXLdn9qhXkWPiWbK5H7JWBW1Bebj/SuQ==",
       "requires": {
         "event-iterator": "^2.0.0",
         "iso-url": "^1.1.2",
         "it-stream-types": "^1.0.2",
-        "uint8arrays": "^3.0.0",
+        "uint8arrays": "^4.0.2",
         "ws": "^8.4.0"
       }
     },
@@ -16225,6 +14720,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -16253,9 +14749,9 @@
       "dev": true
     },
     "json-schema-typed": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
-      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.1.tgz",
+      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -16267,7 +14763,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -16305,167 +14801,147 @@
       }
     },
     "libp2p": {
-      "version": "0.37.3",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.37.3.tgz",
-      "integrity": "sha512-G+0tWT6jZr05XE9bG8Kw1SqFrkt1X3bM9TDDXkqWqHvUVjBHWGNDysOvTp7p3jxoSj4J/Z2w9wGbdDsz1kfPlw==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.42.2.tgz",
+      "integrity": "sha512-arTOCJEEmAFw5HjlXdULVAFs7Y/dWZmgX/qN4SzuxtSkB0pa+fqn/DIbIfpBi2BuY+QozvnARPF1xJtSdqfqJQ==",
       "requires": {
         "@achingbrain/nat-port-mapper": "^1.0.3",
-        "@libp2p/connection": "^2.0.2",
-        "@libp2p/crypto": "^0.22.11",
-        "@libp2p/interfaces": "^2.0.2",
-        "@libp2p/logger": "^1.1.4",
-        "@libp2p/multistream-select": "^1.0.4",
-        "@libp2p/peer-collections": "^1.0.2",
-        "@libp2p/peer-id": "^1.1.10",
-        "@libp2p/peer-id-factory": "^1.0.9",
-        "@libp2p/peer-record": "^1.0.8",
-        "@libp2p/peer-store": "^1.0.10",
-        "@libp2p/tracked-map": "^1.0.5",
-        "@libp2p/utils": "^1.0.10",
+        "@libp2p/crypto": "^1.0.4",
+        "@libp2p/interface-address-manager": "^2.0.0",
+        "@libp2p/interface-connection": "^3.0.2",
+        "@libp2p/interface-connection-encrypter": "^3.0.1",
+        "@libp2p/interface-connection-manager": "^1.1.1",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interface-libp2p": "^1.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-discovery": "^1.0.1",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-routing": "^1.0.1",
+        "@libp2p/interface-peer-store": "^1.2.2",
+        "@libp2p/interface-pubsub": "^3.0.0",
+        "@libp2p/interface-registrar": "^2.0.3",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interface-transport": "^2.1.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.1",
+        "@libp2p/multistream-select": "^3.0.0",
+        "@libp2p/peer-collections": "^3.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-id-factory": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@libp2p/peer-store": "^6.0.0",
+        "@libp2p/tracked-map": "^3.0.0",
+        "@libp2p/utils": "^3.0.2",
         "@multiformats/mafmt": "^11.0.2",
-        "@multiformats/multiaddr": "^10.1.8",
+        "@multiformats/multiaddr": "^11.0.0",
         "abortable-iterator": "^4.0.2",
         "any-signal": "^3.0.0",
-        "datastore-core": "^7.0.0",
+        "datastore-core": "^8.0.1",
         "err-code": "^3.0.1",
         "events": "^3.3.0",
         "hashlru": "^2.3.0",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-drain": "^1.0.5",
-        "it-filter": "^1.0.3",
-        "it-first": "^1.0.6",
-        "it-foreach": "^0.1.1",
-        "it-handshake": "^3.0.1",
-        "it-length-prefixed": "^7.0.1",
-        "it-map": "^1.0.6",
-        "it-merge": "^1.0.3",
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-drain": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-first": "^2.0.0",
+        "it-foreach": "^1.0.0",
+        "it-handshake": "^4.1.2",
+        "it-length-prefixed": "^8.0.2",
+        "it-map": "^2.0.0",
+        "it-merge": "^2.0.0",
         "it-pair": "^2.0.2",
         "it-pipe": "^2.0.3",
-        "it-sort": "^1.0.1",
+        "it-sort": "^2.0.0",
         "it-stream-types": "^1.0.4",
         "merge-options": "^3.0.4",
-        "multiformats": "^9.6.3",
-        "mutable-proxy": "^1.0.0",
-        "node-forge": "^1.2.1",
+        "multiformats": "^11.0.0",
+        "node-forge": "^1.3.1",
         "p-fifo": "^1.0.0",
         "p-retry": "^5.0.0",
         "p-settle": "^5.0.0",
-        "private-ip": "^2.3.3",
-        "protons-runtime": "^1.0.4",
+        "private-ip": "^3.0.0",
+        "protons-runtime": "^4.0.1",
+        "rate-limiter-flexible": "^2.3.11",
         "retimer": "^3.0.0",
         "sanitize-filename": "^1.6.3",
         "set-delayed-interval": "^1.0.0",
         "timeout-abort-controller": "^3.0.0",
-        "uint8arrays": "^3.0.0",
-        "wherearewe": "^1.0.0",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2",
+        "wherearewe": "^2.0.0",
         "xsalsa20": "^1.1.0"
       },
       "dependencies": {
-        "@libp2p/crypto": {
-          "version": "0.22.14",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-0.22.14.tgz",
-          "integrity": "sha512-5RyGh5ovfqrDD8Io3n5rvVnsTHBf1exIMZ/5eBw7Eoy21xkmzdF1Hy701SoSNmiCuTPXYmxT5WMy2VUDBUG6oQ==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.1",
-            "@noble/ed25519": "^1.6.0",
-            "@noble/secp256k1": "^1.5.4",
-            "err-code": "^3.0.1",
-            "iso-random-stream": "^2.0.0",
-            "multiformats": "^9.4.5",
-            "node-forge": "^1.1.0",
-            "protons-runtime": "^1.0.4",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
-        },
-        "@libp2p/peer-collections": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-1.0.3.tgz",
-          "integrity": "sha512-xrnFlZ2CpYiUQ0fGE0WqfBONiE2rjkjWHXnS6gH7CudlD0JMSftbzI+naBXRunfZal7CNEtHN7+keVX+ingPgA==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "@libp2p/peer-id": "^1.1.0"
-          }
-        },
-        "@libp2p/utils": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-1.0.10.tgz",
-          "integrity": "sha512-jlVLfac1IoBlgXL8V+XZYxNw0SOAkKweiLhXWolUbKOgRtMDquJzbwG1n8y9GtdiFKPlkiBwOB7l9xighcOR6w==",
-          "requires": {
-            "@achingbrain/ip-address": "^8.1.0",
-            "@libp2p/logger": "^1.0.1",
-            "@multiformats/multiaddr": "^10.1.1",
-            "abortable-iterator": "^4.0.2",
-            "err-code": "^3.0.1",
-            "is-loopback-addr": "^2.0.1",
-            "it-stream-types": "^1.0.4",
-            "private-ip": "^2.1.1",
-            "ts-mocha": "^9.0.2",
-            "ts-node": "^10.7.0"
-          }
-        },
         "any-signal": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
           "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
         },
-        "it-handshake": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-3.0.1.tgz",
-          "integrity": "sha512-Rx9ESanlfnC0aMw2LtLJ9YNlCNgnZU7wOHPzPSZTUAjbdZx54kllGR5ndIuoJqF2EtNIsmTiWEncKTgwHNJSSg==",
+        "interface-datastore": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+          "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
           "requires": {
-            "it-map": "^1.0.6",
-            "it-pushable": "^2.0.1",
-            "it-reader": "^5.0.0",
-            "it-stream-types": "^1.0.4",
-            "p-defer": "^4.0.0"
+            "interface-store": "^3.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+          "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
+        },
+        "it-all": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+          "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA=="
+        },
+        "it-drain": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.1.tgz",
+          "integrity": "sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ=="
+        },
+        "it-filter": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+          "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg=="
+        },
+        "it-first": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
+          "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw=="
+        },
+        "it-map": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+          "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ=="
+        },
+        "it-merge": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+          "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
+          "requires": {
+            "it-pushable": "^3.1.0"
           }
         },
         "it-pipe": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-          "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+          "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
           "requires": {
-            "it-merge": "^1.0.4",
+            "it-merge": "^2.0.0",
             "it-pushable": "^3.1.0",
             "it-stream-types": "^1.0.3"
-          },
-          "dependencies": {
-            "it-pushable": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-              "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-            }
           }
         },
-        "it-reader": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-5.0.2.tgz",
-          "integrity": "sha512-OgcWA/ffAALrkuUN2sQsbKa3of5oOyLvlXJgSCZdn9sSLZ0rnNmtsJ3lP/WEfWJH8aUNs3bfG6ja3QXKcCOwFw==",
-          "requires": {
-            "it-stream-types": "^1.0.4",
-            "uint8arraylist": "^1.2.0"
-          }
-        },
-        "protons-runtime": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-          "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-          "requires": {
-            "uint8arraylist": "^1.4.0",
-            "uint8arrays": "^3.0.0"
-          }
+        "nanoid": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+          "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww=="
         },
         "retimer": {
           "version": "3.0.0",
@@ -16478,22 +14954,6 @@
           "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
           "requires": {
             "retimer": "^3.0.0"
-          }
-        },
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "wherearewe": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
-          "integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
-          "requires": {
-            "is-electron": "^2.2.0"
           }
         }
       }
@@ -16522,8 +14982,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -16531,77 +14990,10 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "peer": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "peer": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "peer": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "peer": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "peer": true
-        },
-        "is-unicode-supported": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-          "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-          "peer": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "peer": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "long": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "longbits": {
       "version": "1.1.0",
@@ -16633,11 +15025,6 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.12.tgz",
       "integrity": "sha512-Rkukya32FnY3dF5nJeAS4Qcry76tXeOe2sXIQGAt969sV04QLormWHXmHn4o/yIbb4wRlnCqWu8fpVg3TU7sFg=="
-    },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -16742,8 +15129,7 @@
     "mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
     },
     "min-indent": {
       "version": "1.0.1",
@@ -16752,28 +15138,28 @@
       "dev": true
     },
     "miniflare": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.10.0.tgz",
-      "integrity": "sha512-WPveqChVDdmDGv+wFqXjFqEZlZ5/aBlAKX37h/e4TAjl2XsK5nPfQATP8jZXwNDEC5iE29bYZymOqeZkp+t7OA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.9.0.tgz",
+      "integrity": "sha512-HBGQ5Jj6sMU1B1hX6G3ML46ThtUvu1nvxgXjDDmhp2RhWKYj0XvcohW/nPPL/MTP1gpvfT880De9EHmobVsDsw==",
       "dev": true,
       "requires": {
-        "@miniflare/cache": "2.10.0",
-        "@miniflare/cli-parser": "2.10.0",
-        "@miniflare/core": "2.10.0",
-        "@miniflare/d1": "2.10.0",
-        "@miniflare/durable-objects": "2.10.0",
-        "@miniflare/html-rewriter": "2.10.0",
-        "@miniflare/http-server": "2.10.0",
-        "@miniflare/kv": "2.10.0",
-        "@miniflare/queues": "2.10.0",
-        "@miniflare/r2": "2.10.0",
-        "@miniflare/runner-vm": "2.10.0",
-        "@miniflare/scheduler": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/sites": "2.10.0",
-        "@miniflare/storage-file": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0",
-        "@miniflare/web-sockets": "2.10.0",
+        "@miniflare/cache": "2.9.0",
+        "@miniflare/cli-parser": "2.9.0",
+        "@miniflare/core": "2.9.0",
+        "@miniflare/d1": "2.9.0",
+        "@miniflare/durable-objects": "2.9.0",
+        "@miniflare/html-rewriter": "2.9.0",
+        "@miniflare/http-server": "2.9.0",
+        "@miniflare/kv": "2.9.0",
+        "@miniflare/queues": "2.9.0",
+        "@miniflare/r2": "2.9.0",
+        "@miniflare/runner-vm": "2.9.0",
+        "@miniflare/scheduler": "2.9.0",
+        "@miniflare/shared": "2.9.0",
+        "@miniflare/sites": "2.9.0",
+        "@miniflare/storage-file": "2.9.0",
+        "@miniflare/storage-memory": "2.9.0",
+        "@miniflare/web-sockets": "2.9.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -16792,7 +15178,8 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -16819,239 +15206,6 @@
         }
       }
     },
-    "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "requires": {
-        "minimist": "^1.2.6"
-      }
-    },
-    "mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
-      "peer": true,
-      "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.3",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.1",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "peer": true
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "peer": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "peer": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "peer": true
-            }
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "peer": true
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "peer": true
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "peer": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-          "peer": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-              "peer": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "peer": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "peer": true
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "peer": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
-          "peer": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "nanoid": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-          "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
-          "peer": true
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "peer": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "peer": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "peer": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "peer": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "peer": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "peer": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-          "peer": true
-        },
-        "yocto-queue": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-          "peer": true
-        }
-      }
-    },
     "mortice": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.1.tgz",
@@ -17064,14 +15218,14 @@
       },
       "dependencies": {
         "nanoid": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-          "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+          "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww=="
         },
         "p-timeout": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
-          "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA=="
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
+          "integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w=="
         }
       }
     },
@@ -17111,6 +15265,23 @@
         "multiformats": "^9.4.5",
         "uint8arrays": "^3.0.0",
         "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "dev": true
+        },
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        }
       }
     },
     "multiaddr-to-uri": {
@@ -17123,9 +15294,9 @@
       }
     },
     "multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -17138,15 +15309,11 @@
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "dev": true
     },
-    "mutable-proxy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mutable-proxy/-/mutable-proxy-1.0.0.tgz",
-      "integrity": "sha512-4OvNRr1DJpy2QuDUV74m+BWZ//n4gG4bmd21MzDSPqHEidIDWqwyOjcadU1LBMO3vXYGurVKjfBrxrSQIHFu9A=="
-    },
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true
     },
     "native-abort-controller": {
       "version": "1.0.4",
@@ -17209,7 +15376,8 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "npm-run-path": {
       "version": "5.1.0",
@@ -17322,6 +15490,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -17406,9 +15575,9 @@
       }
     },
     "p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
+      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
       "requires": {
         "eventemitter3": "^4.0.7",
         "p-timeout": "^5.0.2"
@@ -17420,9 +15589,9 @@
       "integrity": "sha512-3sG3UlpisPSaX+o7u2q01hIQmrpkvdl5GSO1ZwL7pfc5kHB2bPF0eFNCfYTrW1/LTUdgmPwBAvmT0Zr8eSmaAQ=="
     },
     "p-retry": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.1.tgz",
-      "integrity": "sha512-i69WkEU5ZAL8mrmdmVviWwU+DN+IUF8f4sSJThoJ3z5A7Nn5iuO5ROX3Boye0u+uYQLOSfgFl7SuFZCjlAVbQA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
       "requires": {
         "@types/retry": "0.12.1",
         "retry": "^0.13.1"
@@ -17445,7 +15614,8 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -17483,9 +15653,9 @@
       }
     },
     "parse-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
+      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
       "dev": true
     },
     "parse-package-name": {
@@ -17497,12 +15667,14 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -17524,7 +15696,8 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -17542,53 +15715,10 @@
         "load-json-file": "^7.0.0"
       }
     },
-    "pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-      "requires": {
-        "find-up": "^3.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
-        }
-      }
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "plur": {
       "version": "5.1.0",
@@ -17606,23 +15736,30 @@
       "dev": true
     },
     "pretty-ms": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
+      "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
       "dev": true,
       "requires": {
-        "parse-ms": "^2.1.0"
+        "parse-ms": "^3.0.0"
       }
     },
     "private-ip": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-2.3.4.tgz",
-      "integrity": "sha512-ts/YFVwfBeLq61f9+KsOhXW6RH0wvY0gU50R6QZYzgFhggyyLK6WDFeYdjfi/HMnBm2hecLvsR3PB3JcRxDk+A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.0.tgz",
+      "integrity": "sha512-HkMBs4nMtrP+cvcw0bDi2BAZIGgiKI4Zq8Oc+dMqNBpHS8iGL4+WO/pRtc8Bwnv9rjnV0QwMDwEBymFtqv7Kww==",
       "requires": {
-        "ip-regex": "^4.3.0",
+        "@chainsafe/is-ip": "^2.0.1",
+        "ip-regex": "^5.0.0",
         "ipaddr.js": "^2.0.1",
-        "is-ip": "^3.1.0",
         "netmask": "^2.0.2"
+      },
+      "dependencies": {
+        "ip-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
+        }
       }
     },
     "prop-types": {
@@ -17637,9 +15774,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
+      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -17656,15 +15793,12 @@
       }
     },
     "protons-runtime": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-2.0.2.tgz",
-      "integrity": "sha512-6aBGGn4scICr82Emc6+rS1qhxp9I5YUdfaR4lR10BJ6skyQxbh1vEHkrzGqQrawogwbChDrjLG8H6dI+PLh2tg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-4.0.2.tgz",
+      "integrity": "sha512-R4N6qKHgz8T2Gl45CTcZfITzXPQY9ym8lbLb4VyFMS4ag1KusCRZwkQXTBRhxQ+93ck3K3aDhK1wIk98AMtNyw==",
       "requires": {
-        "byte-access": "^1.0.1",
-        "longbits": "^1.1.0",
-        "uint8-varint": "^1.0.2",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
       }
     },
     "punycode": {
@@ -17698,14 +15832,10 @@
         "readable-stream": "^3.6.0"
       }
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "peer": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
+    "rate-limiter-flexible": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.1.tgz",
+      "integrity": "sha512-dgH4T44TzKVO9CLArNto62hJOwlWJMLUjVVr/ii0uUzZXEXthDNr7/yefW5z/1vvHAfycc1tnuiYyNJ8CTRB3g=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -17834,6 +15964,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -17844,6 +15975,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -17979,7 +16111,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safe-regex-test": {
       "version": "1.0.0",
@@ -18027,9 +16160,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -18049,15 +16182,6 @@
           "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
           "dev": true
         }
-      }
-    },
-    "serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "peer": true,
-      "requires": {
-        "randombytes": "^2.1.0"
       }
     },
     "set-cookie-parser": {
@@ -18125,6 +16249,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -18180,9 +16305,9 @@
       "dev": true
     },
     "stack-utils": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -18324,13 +16449,13 @@
     "streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -18397,7 +16522,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "devOptional": true
+      "dev": true
     },
     "strip-final-newline": {
       "version": "3.0.0",
@@ -18417,17 +16542,13 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
     },
-    "super-regex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
-      "integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
-      "requires": {
-        "clone-regexp": "^3.0.0",
-        "function-timeout": "^0.1.0",
-        "time-span": "^5.1.0"
-      }
+    "stubborn-fs": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
+      "integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w=="
     },
     "supertap": {
       "version": "3.0.1",
@@ -18478,9 +16599,9 @@
       "dev": true
     },
     "temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true
     },
     "text-table": {
@@ -18488,14 +16609,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
-    },
-    "time-span": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
-      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
-      "requires": {
-        "convert-hrtime": "^5.0.0"
-      }
     },
     "time-zone": {
       "version": "1.0.0",
@@ -18517,6 +16630,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -18535,79 +16649,11 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
-    "ts-mocha": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-9.0.2.tgz",
-      "integrity": "sha512-WyQjvnzwrrubl0JT7EC1yWmNpcsU3fOuBFfdps30zbmFBgKniSaSOyZMZx+Wq7kytUs5CY+pEbSYEbGfIKnXTw==",
-      "requires": {
-        "ts-node": "7.0.1",
-        "tsconfig-paths": "^3.5.0"
-      },
-      "dependencies": {
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="
-        },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-        },
-        "ts-node": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-          "requires": {
-            "arrify": "^1.0.0",
-            "buffer-from": "^1.1.0",
-            "diff": "^3.1.0",
-            "make-error": "^1.1.1",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "source-map-support": "^0.5.6",
-            "yn": "^2.0.0"
-          }
-        },
-        "yn": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-          "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ=="
-        }
-      }
-    },
-    "ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "requires": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-        }
-      }
-    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
       "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
@@ -18630,43 +16676,37 @@
       "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
       "dev": true
     },
-    "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "peer": true
-    },
     "uglify-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
-      "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "peer": true
     },
     "uint8-varint": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.3.tgz",
-      "integrity": "sha512-ESs/P/AYPy2wWZCT2V6Tg7RPqA6jzlhJbdsNPFvbDeIrDxj12dwTcm0rD9yFlnmgEf6vRBCZrP3d0SiRTcPwSQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.4.tgz",
+      "integrity": "sha512-FHnaReHRIM7kHe/Ms0I2KGkuSY4o7ouhUJGJeiFEuYWGvBt4Y64+BJ3mV6DqmyYtYTZj4Pz8K/BmViSNFLRrVw==",
       "requires": {
         "byte-access": "^1.0.0",
         "longbits": "^1.1.0",
         "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.1.0"
+        "uint8arrays": "^4.0.2"
       }
     },
     "uint8arraylist": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.3.2.tgz",
-      "integrity": "sha512-4ybc/jixmtGhUrebJ0bzB95TjEbskWxBKBRrAozw7P6WcAcZdPMYSLdDuNoEEGo/Cwe+0TNic9CXzWUWzy1quw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
       "requires": {
-        "uint8arrays": "^3.1.0"
+        "uint8arrays": "^4.0.2"
       }
     },
     "uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
       "requires": {
-        "multiformats": "^9.4.2"
+        "multiformats": "^11.0.0"
       }
     },
     "unbox-primitive": {
@@ -18684,7 +16724,8 @@
     "undici": {
       "version": "5.9.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.9.1.tgz",
-      "integrity": "sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg=="
+      "integrity": "sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",
@@ -18722,17 +16763,13 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
-    "v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -18779,6 +16816,11 @@
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
       "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
       "dev": true
+    },
+    "when-exit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.0.tgz",
+      "integrity": "sha512-H85ulNwUBU1e6PGxkWUDgxnbohSXD++ah6Xw1VHAN7CtypcbZaC4aYjQ+C2PMVaDkURDuOinNAT+Lnz3utWXxQ=="
     },
     "wherearewe": {
       "version": "2.0.1",
@@ -18828,12 +16870,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
-    },
-    "workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-      "peer": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -18904,12 +16940,13 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
+      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",
@@ -18917,9 +16954,9 @@
       }
     },
     "ws": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "requires": {}
     },
     "xdg-basedir": {
@@ -18958,9 +16995,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "requires": {
         "cliui": "^8.0.1",
@@ -18969,7 +17006,7 @@
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -19022,37 +17059,6 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
-    },
-    "yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "peer": true,
-      "requires": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-          "peer": true
-        },
-        "decamelize": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-          "peer": true
-        }
-      }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,29 +23,28 @@
   "author": "Alan Shaw",
   "license": "Apache-2.0 OR MIT",
   "dependencies": {
-    "@ipld/car": "^4.1.5",
-    "@ipld/dag-cbor": "^7.0.3",
-    "@ipld/dag-json": "^8.0.11",
-    "@ipld/dag-pb": "^2.1.18",
-    "@web3-storage/fast-unixfs-exporter": "^0.2.0",
-    "@web3-storage/gateway-lib": "^2.0.2",
-    "cardex": "^1.0.0",
+    "@ipld/car": "^5.1.0",
+    "@ipld/dag-cbor": "^9.0.0",
+    "@ipld/dag-json": "^10.0.1",
+    "@ipld/dag-pb": "^4.0.2",
+    "@web3-storage/gateway-lib": "^2.0.3",
+    "cardex": "^1.0.1",
     "chardet": "^1.5.0",
-    "dagula": "^4.1.1",
+    "dagula": "^5.0.0",
     "magic-bytes.js": "^1.0.12",
     "mrmime": "^1.0.1",
-    "multiformats": "^9.9.0",
+    "multiformats": "^11.0.2",
     "p-defer": "^4.0.0",
     "streaming-iterables": "^7.1.0"
   },
   "devDependencies": {
-    "ava": "^4.3.3",
+    "ava": "^5.2.0",
     "carbites": "^1.0.6",
-    "esbuild": "^0.15.10",
+    "esbuild": "^0.17.11",
     "files-from-path": "^0.2.6",
-    "ipfs-car": "^0.8.1",
+    "ipfs-car": "^0.9.2",
     "miniflare": "^2.9.0",
     "standard": "^17.0.0",
-    "uint8arrays": "^3.1.1"
+    "uint8arrays": "^4.0.3"
   }
 }

--- a/scripts/r2-put.js
+++ b/scripts/r2-put.js
@@ -11,7 +11,7 @@ import { Builder } from '../test/helpers.js'
 
 const bucketNames = ['CARPARK', 'SATNAV', 'DUDEWHERE']
 const buckets = bucketNames.map(b => new R2Bucket(new FileStorage(`./.mf/r2/${b}`)))
-const builder = new Builder(...buckets)
+const builder = new Builder(buckets[0], buckets[1], buckets[2])
 
 const paths = process.argv.slice(2).filter(p => p !== '--no-wrap')
 const files = await getFilesFromPath(paths)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -35,7 +35,7 @@ export class Builder {
   }
 
   /**
-   * @param {CID} cid CAR CID
+   * @param {import('multiformats').Link} cid CAR CID
    * @param {Uint8Array} bytes CAR file bytes
    */
   async #writeIndex (cid, bytes) {
@@ -51,8 +51,8 @@ export class Builder {
   }
 
   /**
-   * @param {CID} dataCid
-   * @param {CID[]} carCids
+   * @param {import('multiformats').UnknownLink} dataCid
+   * @param {import('multiformats').Link[]} carCids
    */
   async #writeLinks (dataCid, carCids) {
     await Promise.all(carCids.map(cid => (
@@ -84,6 +84,7 @@ export class Builder {
       carCids.push(carCid)
     }
 
+    // @ts-ignore old multiformats in ipfs-car
     await this.#writeLinks(dataCid, carCids)
 
     return { dataCid, carCids }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -30,7 +30,7 @@ describe('freeway', () => {
     })
 
     const buckets = await Promise.all(bucketNames.map(b => miniflare.getR2Bucket(b)))
-    builder = new Builder(...buckets)
+    builder = new Builder(buckets[0], buckets[1], buckets[2])
   })
 
   it('should get a file', async () => {


### PR DESCRIPTION
Pulls in the new `gateway-lib` with the fix for allowing hash character in directory listings.

Also updates all dependencies, which includes a change in dagula to switch from our unixfs exporter fork back to `ipfs-unixfs-exporter` (since the parallel block fetching from the fork was backported).

`ipfs-unixfs-exporter` now uses `.subarray()` everywhere (no buffer copies) which is rad, but it also caused our tests to fail which was tricky to track down the cause. I've commented heavily in the place where the fix is.

