### PR TITLE
fix: update max shards values

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -40,10 +40,10 @@ export function withCarCids (handler) {
     if (!ctx.dataCid) throw new Error('missing data CID')
     if (!ctx.searchParams) throw new Error('missing URL search params')
 
-    // Cloudflare currently sets a limit of 1000 sub-requests within the worker context
+    // Cloudflare currently sets a limit of 3300 sub-requests within the worker context
     // If we have a given root CID splitted across hundreds of CARs, freeway will hit
     // the sub-requests limit and not serve content anyway
-    const maxShards = env.MAX_SHARDS ? parseInt(env.MAX_SHARDS) : 250
+    const maxShards = env.MAX_SHARDS ? parseInt(env.MAX_SHARDS) : 825
 
     const carCids = ctx.searchParams.getAll('origin').flatMap(str => {
       return str.split(',')

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,7 +28,7 @@ r2_buckets = [
 command = "npm run build"
 
 [env.production.vars]
-MAX_SHARDS = "250"
+MAX_SHARDS = "825"
 
 # Staging!
 [env.staging]
@@ -44,7 +44,7 @@ r2_buckets = [
 command = "npm run build"
 
 [env.staging.vars]
-MAX_SHARDS = "250"
+MAX_SHARDS = "825"
 
 # Test!
 [env.test]


### PR DESCRIPTION
Per the new sub requests max limit of 3300, increasing the maximum of shards that we attempt to get.