### PR TITLE
feat: support CAR block ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
-        "@web3-storage/gateway-lib": "^3.0.0",
+        "@web3-storage/gateway-lib": "^3.1.0",
         "cardex": "^1.0.1",
         "chardet": "^1.5.0",
         "dagula": "^6.0.1",
@@ -221,6 +221,183 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-4.0.2.tgz",
+      "integrity": "sha512-p0m/4ab4JLaIQqUtxvm8bSqdt9sb0uXX8PFj1CQM1eJLeV1LxzzygaSOeLxN/5ckHCuK7q/9eb9xybvl6vz/JA==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.1.0",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/logger": "^2.0.7",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/@libp2p/interface-connection": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-5.1.0.tgz",
+      "integrity": "sha512-KFjCnGvFVlu0hHS/O8NOsst32mIzUQEkRWq5EhOBehXjjpOJBcm8XQaqmhBlxVfHEYm7XQsztEtFumveszzm1A==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/@libp2p/interface-stream-muxer": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-4.1.2.tgz",
+      "integrity": "sha512-dQJcn67UaAa8YQFRJDhbo4uT453z/2lCzD/ZwTk1YOqJxATXbXgVcB8dXDQFEUiUX3ZjVQ1IBu+NlQd+IZ++zw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@libp2p/logger": "^2.0.7",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "it-pushable": "^3.1.3",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.3.tgz",
+      "integrity": "sha512-rNcS3njkkSwuGF4x58L47jGH5kBXBfJPNsWnrt0gujhNYn6ReDt1je7vEU5/ddrVj0TStgxw+Hm+TkYDK0b60w==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/abortable-iterator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+      "dependencies": {
+        "get-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/dns-over-http-resolver": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
+      "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/get-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-2.0.0.tgz",
+      "integrity": "sha512-BDJawD5PU2gZv6Vlp8O28H4GnZcsr3h9gZUvnAP5xXP3WOy/QAoOsyMepSkw21jur+4t5Vppde72ChjhTIzxzg=="
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/it-merge": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.1.tgz",
+      "integrity": "sha512-I6hjU1ABO+k3xY1H6JtCSDXvUME88pxIXSgKeT4WI5rPYbQzpr98ldacVuG95WbjaJxKl6Qot6lUdxduLBQPHA==",
+      "dependencies": {
+        "it-pushable": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "dependencies": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/native-fetch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
+      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
+      "peerDependencies": {
+        "undici": "*"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux/node_modules/undici": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -1028,18 +1205,18 @@
       }
     },
     "node_modules/@libp2p/interfaces": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
-      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.2.tgz",
+      "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.6.tgz",
-      "integrity": "sha512-PfTGCBT6buiGeww7heG1JucBK2io2sJ2hntNh+gTVohRy4FyEvZixnWfIVD2rCM8EsbZu3Hmt/qqetzX5BrziQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.7.tgz",
+      "integrity": "sha512-Zp9C9lMNGfVFTMVc7NvxuxMvIE6gyxDapQc/TqZH02IuIDl1JpZyCgNILr0APd8wcUxwvwRXYNf3kQ0Lmz7tuQ==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "debug": "^4.3.3",
@@ -2146,20 +2323,85 @@
       }
     },
     "node_modules/@web3-storage/gateway-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-3.0.0.tgz",
-      "integrity": "sha512-ltjDDaJgN93CBx1Uo87oLf7aDjHfDK/QtqzC+gZfwPFL0+Z47KUJ1nyGJIfQANEN5gn5tvEz9bdyT62sx8HrLQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-3.1.0.tgz",
+      "integrity": "sha512-kXpPjR5iUA5aam6TNI0RWizuqwYyTs0bOB/yR48qp37FOvbWkOp7VP1GmGcobsrGgStMcXIXM9mqmcg/Al1JYA==",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "@web3-storage/handlebars": "^1.0.0",
         "bytes": "^3.1.2",
         "chardet": "^1.5.0",
-        "dagula": "^6.0.2",
+        "dagula": "^7.0.0",
         "magic-bytes.js": "^1.0.12",
         "mrmime": "^1.0.1",
         "multiformats": "^11.0.1",
         "timeout-abort-controller": "^3.0.0",
         "uint8arrays": "^4.0.3"
+      }
+    },
+    "node_modules/@web3-storage/gateway-lib/node_modules/dagula": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dagula/-/dagula-7.0.0.tgz",
+      "integrity": "sha512-DqZC/SMWId/3M7E524fuKM3UUm/CJjfuXLRbYtS0RfMOZtzzbGaISq43aRlzfdt7JvnZa4VbC6ZoPj5JDsPZWQ==",
+      "dependencies": {
+        "@chainsafe/libp2p-noise": "^11.0.0",
+        "@chainsafe/libp2p-yamux": "^4.0.2",
+        "@ipld/car": "^5.0.3",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/interface-connection": "^3.0.8",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-registrar": "^2.0.8",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/mplex": "^7.1.1",
+        "@libp2p/tcp": "^6.0.9",
+        "@libp2p/websockets": "^5.0.3",
+        "@multiformats/blake2": "^1.0.13",
+        "@multiformats/multiaddr": "^11.3.0",
+        "archy": "^1.0.0",
+        "conf": "^11.0.1",
+        "debug": "^4.3.4",
+        "ipfs-unixfs-exporter": "^12.0.2",
+        "it-length-prefixed": "^8.0.4",
+        "it-pipe": "^2.0.3",
+        "libp2p": "^0.42.2",
+        "multiformats": "^11.0.1",
+        "p-defer": "^4.0.0",
+        "protobufjs": "^7.0.0",
+        "sade": "^1.8.1",
+        "streaming-iterables": "^7.0.4",
+        "timeout-abort-controller": "^3.0.0",
+        "varint": "^6.0.0"
+      },
+      "bin": {
+        "dagula": "bin.js"
+      }
+    },
+    "node_modules/@web3-storage/gateway-lib/node_modules/it-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+      "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
+      "dependencies": {
+        "it-pushable": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@web3-storage/gateway-lib/node_modules/it-pipe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
+      "dependencies": {
+        "it-merge": "^2.0.0",
+        "it-pushable": "^3.1.0",
+        "it-stream-types": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@web3-storage/gateway-lib/node_modules/retimer": {
@@ -6483,9 +6725,9 @@
       "dev": true
     },
     "node_modules/it-pushable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
-      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.3.tgz",
+      "integrity": "sha512-f50iQ85HISS6DaWCyrqf9QJ6G/kQtKIMf9xZkgZgyOvxEQDfn8OfYcLXXquCqgoLboxQtAW1ZFZyFIAsLHDtJw==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -10012,6 +10254,140 @@
         }
       }
     },
+    "@chainsafe/libp2p-yamux": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-4.0.2.tgz",
+      "integrity": "sha512-p0m/4ab4JLaIQqUtxvm8bSqdt9sb0uXX8PFj1CQM1eJLeV1LxzzygaSOeLxN/5ckHCuK7q/9eb9xybvl6vz/JA==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.1.0",
+        "@libp2p/interface-stream-muxer": "^4.1.2",
+        "@libp2p/interfaces": "^3.3.2",
+        "@libp2p/logger": "^2.0.7",
+        "abortable-iterator": "^5.0.1",
+        "any-signal": "^4.1.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.1.3",
+        "uint8arraylist": "^2.4.3"
+      },
+      "dependencies": {
+        "@libp2p/interface-connection": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-5.1.0.tgz",
+          "integrity": "sha512-KFjCnGvFVlu0hHS/O8NOsst32mIzUQEkRWq5EhOBehXjjpOJBcm8XQaqmhBlxVfHEYm7XQsztEtFumveszzm1A==",
+          "requires": {
+            "@libp2p/interface-peer-id": "^2.0.0",
+            "@libp2p/interfaces": "^3.0.0",
+            "@multiformats/multiaddr": "^12.0.0",
+            "it-stream-types": "^2.0.1",
+            "uint8arraylist": "^2.4.3"
+          }
+        },
+        "@libp2p/interface-stream-muxer": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-4.1.2.tgz",
+          "integrity": "sha512-dQJcn67UaAa8YQFRJDhbo4uT453z/2lCzD/ZwTk1YOqJxATXbXgVcB8dXDQFEUiUX3ZjVQ1IBu+NlQd+IZ++zw==",
+          "requires": {
+            "@libp2p/interface-connection": "^5.0.0",
+            "@libp2p/interfaces": "^3.0.0",
+            "@libp2p/logger": "^2.0.7",
+            "abortable-iterator": "^5.0.1",
+            "any-signal": "^4.1.1",
+            "it-pushable": "^3.1.3",
+            "it-stream-types": "^2.0.1",
+            "uint8arraylist": "^2.4.3"
+          }
+        },
+        "@multiformats/multiaddr": {
+          "version": "12.1.3",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.3.tgz",
+          "integrity": "sha512-rNcS3njkkSwuGF4x58L47jGH5kBXBfJPNsWnrt0gujhNYn6ReDt1je7vEU5/ddrVj0TStgxw+Hm+TkYDK0b60w==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "@chainsafe/netmask": "^2.0.0",
+            "@libp2p/interfaces": "^3.3.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "abortable-iterator": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+          "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+          "requires": {
+            "get-iterator": "^2.0.0",
+            "it-stream-types": "^2.0.1"
+          }
+        },
+        "any-signal": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+          "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA=="
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
+          "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        },
+        "get-iterator": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-2.0.0.tgz",
+          "integrity": "sha512-BDJawD5PU2gZv6Vlp8O28H4GnZcsr3h9gZUvnAP5xXP3WOy/QAoOsyMepSkw21jur+4t5Vppde72ChjhTIzxzg=="
+        },
+        "it-merge": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.1.tgz",
+          "integrity": "sha512-I6hjU1ABO+k3xY1H6JtCSDXvUME88pxIXSgKeT4WI5rPYbQzpr98ldacVuG95WbjaJxKl6Qot6lUdxduLBQPHA==",
+          "requires": {
+            "it-pushable": "^3.1.0"
+          }
+        },
+        "it-pipe": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+          "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+          "requires": {
+            "it-merge": "^3.0.0",
+            "it-pushable": "^3.1.2",
+            "it-stream-types": "^2.0.1"
+          }
+        },
+        "it-stream-types": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+          "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg=="
+        },
+        "native-fetch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
+          "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
+          "requires": {}
+        },
+        "undici": {
+          "version": "5.22.1",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+          "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+          "requires": {
+            "busboy": "^1.6.0"
+          }
+        }
+      }
+    },
+    "@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "requires": {
+        "@chainsafe/is-ip": "^2.0.1"
+      }
+    },
     "@esbuild/android-arm": {
       "version": "0.17.11",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.11.tgz",
@@ -10494,14 +10870,14 @@
       }
     },
     "@libp2p/interfaces": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
-      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.2.tgz",
+      "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g=="
     },
     "@libp2p/logger": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.6.tgz",
-      "integrity": "sha512-PfTGCBT6buiGeww7heG1JucBK2io2sJ2hntNh+gTVohRy4FyEvZixnWfIVD2rCM8EsbZu3Hmt/qqetzX5BrziQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.7.tgz",
+      "integrity": "sha512-Zp9C9lMNGfVFTMVc7NvxuxMvIE6gyxDapQc/TqZH02IuIDl1JpZyCgNILr0APd8wcUxwvwRXYNf3kQ0Lmz7tuQ==",
       "requires": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "debug": "^4.3.3",
@@ -11405,15 +11781,15 @@
       }
     },
     "@web3-storage/gateway-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-3.0.0.tgz",
-      "integrity": "sha512-ltjDDaJgN93CBx1Uo87oLf7aDjHfDK/QtqzC+gZfwPFL0+Z47KUJ1nyGJIfQANEN5gn5tvEz9bdyT62sx8HrLQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-3.1.0.tgz",
+      "integrity": "sha512-kXpPjR5iUA5aam6TNI0RWizuqwYyTs0bOB/yR48qp37FOvbWkOp7VP1GmGcobsrGgStMcXIXM9mqmcg/Al1JYA==",
       "requires": {
         "@ipld/car": "^5.1.0",
         "@web3-storage/handlebars": "^1.0.0",
         "bytes": "^3.1.2",
         "chardet": "^1.5.0",
-        "dagula": "^6.0.2",
+        "dagula": "^7.0.0",
         "magic-bytes.js": "^1.0.12",
         "mrmime": "^1.0.1",
         "multiformats": "^11.0.1",
@@ -11421,6 +11797,60 @@
         "uint8arrays": "^4.0.3"
       },
       "dependencies": {
+        "dagula": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/dagula/-/dagula-7.0.0.tgz",
+          "integrity": "sha512-DqZC/SMWId/3M7E524fuKM3UUm/CJjfuXLRbYtS0RfMOZtzzbGaISq43aRlzfdt7JvnZa4VbC6ZoPj5JDsPZWQ==",
+          "requires": {
+            "@chainsafe/libp2p-noise": "^11.0.0",
+            "@chainsafe/libp2p-yamux": "^4.0.2",
+            "@ipld/car": "^5.0.3",
+            "@ipld/dag-cbor": "^9.0.0",
+            "@ipld/dag-json": "^10.0.0",
+            "@ipld/dag-pb": "^4.0.0",
+            "@libp2p/interface-connection": "^3.0.8",
+            "@libp2p/interface-peer-id": "^2.0.1",
+            "@libp2p/interface-registrar": "^2.0.8",
+            "@libp2p/interfaces": "^3.3.1",
+            "@libp2p/mplex": "^7.1.1",
+            "@libp2p/tcp": "^6.0.9",
+            "@libp2p/websockets": "^5.0.3",
+            "@multiformats/blake2": "^1.0.13",
+            "@multiformats/multiaddr": "^11.3.0",
+            "archy": "^1.0.0",
+            "conf": "^11.0.1",
+            "debug": "^4.3.4",
+            "ipfs-unixfs-exporter": "^12.0.2",
+            "it-length-prefixed": "^8.0.4",
+            "it-pipe": "^2.0.3",
+            "libp2p": "^0.42.2",
+            "multiformats": "^11.0.1",
+            "p-defer": "^4.0.0",
+            "protobufjs": "^7.0.0",
+            "sade": "^1.8.1",
+            "streaming-iterables": "^7.0.4",
+            "timeout-abort-controller": "^3.0.0",
+            "varint": "^6.0.0"
+          }
+        },
+        "it-merge": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+          "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
+          "requires": {
+            "it-pushable": "^3.1.0"
+          }
+        },
+        "it-pipe": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+          "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
+          "requires": {
+            "it-merge": "^2.0.0",
+            "it-pushable": "^3.1.0",
+            "it-stream-types": "^1.0.3"
+          }
+        },
         "retimer": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
@@ -14669,9 +15099,9 @@
       "dev": true
     },
     "it-pushable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
-      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.3.tgz",
+      "integrity": "sha512-f50iQ85HISS6DaWCyrqf9QJ6G/kQtKIMf9xZkgZgyOvxEQDfn8OfYcLXXquCqgoLboxQtAW1ZFZyFIAsLHDtJw=="
     },
     "it-reader": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@ipld/dag-cbor": "^9.0.0",
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
-    "@web3-storage/gateway-lib": "^3.0.0",
+    "@web3-storage/gateway-lib": "^3.1.0",
     "cardex": "^1.0.1",
     "chardet": "^1.5.0",
     "dagula": "^6.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -55,10 +55,10 @@ async function handler (request, env, ctx) {
   const { searchParams } = ctx
   if (!searchParams) throw new Error('missing URL search params')
 
-  if (searchParams.get('format') === 'raw' || headers.get('Accept') === 'application/vnd.ipld.raw') {
+  if (searchParams.get('format') === 'raw' || headers.get('Accept')?.includes('application/vnd.ipld.raw')) {
     return await handleBlock(request, env, ctx)
   }
-  if (searchParams.get('format') === 'car' || headers.get('Accept') === 'application/vnd.ipld.car') {
+  if (searchParams.get('format') === 'car' || headers.get('Accept')?.includes('application/vnd.ipld.car')) {
     return await handleCar(request, env, ctx)
   }
   return await handleUnixfs(request, env, ctx)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -85,7 +85,7 @@ describe('freeway', () => {
     const { dataCid } = await builder.add(input, { wrapWithDirectory: false })
 
     const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}`, {
-      headers: { Accept: `application/vnd.ipld.car;order=dfs;` }
+      headers: { Accept: 'application/vnd.ipld.car;order=dfs;' }
     })
     if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,6 +3,7 @@ import assert from 'node:assert'
 import { randomBytes } from 'node:crypto'
 import { Miniflare } from 'miniflare'
 import { equals } from 'uint8arrays'
+import { CarReader } from '@ipld/car'
 import { Builder } from './helpers.js'
 
 describe('freeway', () => {
@@ -77,5 +78,23 @@ describe('freeway', () => {
 
     assert(!res.ok)
     assert.equal(res.status, 501)
+  })
+
+  it('should get a CAR via Accept headers', async () => {
+    const input = randomBytes(256)
+    const { dataCid } = await builder.add(input, { wrapWithDirectory: false })
+
+    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}`, {
+      headers: { Accept: `application/vnd.ipld.car;order=dfs;` }
+    })
+    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+
+    const contentType = res.headers.get('Content-Type')
+    assert(contentType)
+    assert(contentType.includes('application/vnd.ipld.car'))
+    assert(contentType.includes('order=dfs'))
+
+    const output = new Uint8Array(await res.arrayBuffer())
+    assert.doesNotReject(CarReader.fromBytes(output))
   })
 })


### PR DESCRIPTION
This PR upgrades `gateway-lib` to support CAR block ordering.

Also fixes an issue where the CAR handler would not be invoked when using HTTP `Accept` header that had any parameters following `application/vnd.ipld.car` e.g. `application/vnd.ipld.car;order=dfs;`.