### PR TITLE
fix: update dagula to v7 for ordering support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@web3-storage/gateway-lib": "^3.1.1",
         "cardex": "^1.0.1",
         "chardet": "^1.5.0",
-        "dagula": "^6.0.1",
+        "dagula": "^7.0.0",
         "magic-bytes.js": "^1.0.12",
         "mrmime": "^1.0.1",
         "multiformats": "^11.0.2",
@@ -2339,71 +2339,6 @@
         "uint8arrays": "^4.0.3"
       }
     },
-    "node_modules/@web3-storage/gateway-lib/node_modules/dagula": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-7.0.0.tgz",
-      "integrity": "sha512-DqZC/SMWId/3M7E524fuKM3UUm/CJjfuXLRbYtS0RfMOZtzzbGaISq43aRlzfdt7JvnZa4VbC6ZoPj5JDsPZWQ==",
-      "dependencies": {
-        "@chainsafe/libp2p-noise": "^11.0.0",
-        "@chainsafe/libp2p-yamux": "^4.0.2",
-        "@ipld/car": "^5.0.3",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-json": "^10.0.0",
-        "@ipld/dag-pb": "^4.0.0",
-        "@libp2p/interface-connection": "^3.0.8",
-        "@libp2p/interface-peer-id": "^2.0.1",
-        "@libp2p/interface-registrar": "^2.0.8",
-        "@libp2p/interfaces": "^3.3.1",
-        "@libp2p/mplex": "^7.1.1",
-        "@libp2p/tcp": "^6.0.9",
-        "@libp2p/websockets": "^5.0.3",
-        "@multiformats/blake2": "^1.0.13",
-        "@multiformats/multiaddr": "^11.3.0",
-        "archy": "^1.0.0",
-        "conf": "^11.0.1",
-        "debug": "^4.3.4",
-        "ipfs-unixfs-exporter": "^12.0.2",
-        "it-length-prefixed": "^8.0.4",
-        "it-pipe": "^2.0.3",
-        "libp2p": "^0.42.2",
-        "multiformats": "^11.0.1",
-        "p-defer": "^4.0.0",
-        "protobufjs": "^7.0.0",
-        "sade": "^1.8.1",
-        "streaming-iterables": "^7.0.4",
-        "timeout-abort-controller": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "bin": {
-        "dagula": "bin.js"
-      }
-    },
-    "node_modules/@web3-storage/gateway-lib/node_modules/it-merge": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
-      "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
-      "dependencies": {
-        "it-pushable": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@web3-storage/gateway-lib/node_modules/it-pipe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
-      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
-      "dependencies": {
-        "it-merge": "^2.0.0",
-        "it-pushable": "^3.1.0",
-        "it-stream-types": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@web3-storage/gateway-lib/node_modules/retimer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
@@ -3543,11 +3478,12 @@
       }
     },
     "node_modules/dagula": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-6.0.2.tgz",
-      "integrity": "sha512-NzIwcSMvfIJhDsFDFInPuSPZDwHvFNNq18A+NCzICUNYd0iEpA9+BGAj+WF337g6pqqf54IogOrW99XhxbJjzQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dagula/-/dagula-7.0.0.tgz",
+      "integrity": "sha512-DqZC/SMWId/3M7E524fuKM3UUm/CJjfuXLRbYtS0RfMOZtzzbGaISq43aRlzfdt7JvnZa4VbC6ZoPj5JDsPZWQ==",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^11.0.0",
+        "@chainsafe/libp2p-yamux": "^4.0.2",
         "@ipld/car": "^5.0.3",
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.0",
@@ -11797,60 +11733,6 @@
         "uint8arrays": "^4.0.3"
       },
       "dependencies": {
-        "dagula": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/dagula/-/dagula-7.0.0.tgz",
-          "integrity": "sha512-DqZC/SMWId/3M7E524fuKM3UUm/CJjfuXLRbYtS0RfMOZtzzbGaISq43aRlzfdt7JvnZa4VbC6ZoPj5JDsPZWQ==",
-          "requires": {
-            "@chainsafe/libp2p-noise": "^11.0.0",
-            "@chainsafe/libp2p-yamux": "^4.0.2",
-            "@ipld/car": "^5.0.3",
-            "@ipld/dag-cbor": "^9.0.0",
-            "@ipld/dag-json": "^10.0.0",
-            "@ipld/dag-pb": "^4.0.0",
-            "@libp2p/interface-connection": "^3.0.8",
-            "@libp2p/interface-peer-id": "^2.0.1",
-            "@libp2p/interface-registrar": "^2.0.8",
-            "@libp2p/interfaces": "^3.3.1",
-            "@libp2p/mplex": "^7.1.1",
-            "@libp2p/tcp": "^6.0.9",
-            "@libp2p/websockets": "^5.0.3",
-            "@multiformats/blake2": "^1.0.13",
-            "@multiformats/multiaddr": "^11.3.0",
-            "archy": "^1.0.0",
-            "conf": "^11.0.1",
-            "debug": "^4.3.4",
-            "ipfs-unixfs-exporter": "^12.0.2",
-            "it-length-prefixed": "^8.0.4",
-            "it-pipe": "^2.0.3",
-            "libp2p": "^0.42.2",
-            "multiformats": "^11.0.1",
-            "p-defer": "^4.0.0",
-            "protobufjs": "^7.0.0",
-            "sade": "^1.8.1",
-            "streaming-iterables": "^7.0.4",
-            "timeout-abort-controller": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "it-merge": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
-          "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
-          "requires": {
-            "it-pushable": "^3.1.0"
-          }
-        },
-        "it-pipe": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
-          "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
-          "requires": {
-            "it-merge": "^2.0.0",
-            "it-pushable": "^3.1.0",
-            "it-stream-types": "^1.0.3"
-          }
-        },
         "retimer": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
@@ -12725,11 +12607,12 @@
       }
     },
     "dagula": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-6.0.2.tgz",
-      "integrity": "sha512-NzIwcSMvfIJhDsFDFInPuSPZDwHvFNNq18A+NCzICUNYd0iEpA9+BGAj+WF337g6pqqf54IogOrW99XhxbJjzQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dagula/-/dagula-7.0.0.tgz",
+      "integrity": "sha512-DqZC/SMWId/3M7E524fuKM3UUm/CJjfuXLRbYtS0RfMOZtzzbGaISq43aRlzfdt7JvnZa4VbC6ZoPj5JDsPZWQ==",
       "requires": {
         "@chainsafe/libp2p-noise": "^11.0.0",
+        "@chainsafe/libp2p-yamux": "^4.0.2",
         "@ipld/car": "^5.0.3",
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@web3-storage/gateway-lib": "^3.1.1",
     "cardex": "^1.0.1",
     "chardet": "^1.5.0",
-    "dagula": "^6.0.1",
+    "dagula": "^7.0.0",
     "magic-bytes.js": "^1.0.12",
     "mrmime": "^1.0.1",
     "multiformats": "^11.0.2",


### PR DESCRIPTION
We missed this when landing #38 ...gateway-lib uses dagula, but freeway brings it's own, and it was still using v6

fixes: https://github.com/web3-storage/freeway/issues/42

License: MIT