### PR TITLE
feat: upgrade cardex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
         "@web3-storage/gateway-lib": "^3.1.1",
-        "cardex": "^2.0.1",
+        "cardex": "^2.1.0",
         "chardet": "^1.5.0",
         "dagula": "^7.0.0",
         "magic-bytes.js": "^1.0.12",
@@ -3120,9 +3120,9 @@
       "dev": true
     },
     "node_modules/cardex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.0.1.tgz",
-      "integrity": "sha512-5aH7nX7u8v5hI7TMNiLKsX2ZK2bChzkdtWLl0x0geXuv6HgLSYudaRB5MANRfLlIPNPzZW91rRKHGmPDp/WiSw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.1.0.tgz",
+      "integrity": "sha512-rEo9iXU3C+V6iUqnB7PWdbLvs7odK2a/HG+UQW5Gd2SljZytk6MUNhKsleVE5WCm8IzaLec1/NT2duwUkcoYvA==",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",
@@ -12338,9 +12338,9 @@
       }
     },
     "cardex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.0.1.tgz",
-      "integrity": "sha512-5aH7nX7u8v5hI7TMNiLKsX2ZK2bChzkdtWLl0x0geXuv6HgLSYudaRB5MANRfLlIPNPzZW91rRKHGmPDp/WiSw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.1.0.tgz",
+      "integrity": "sha512-rEo9iXU3C+V6iUqnB7PWdbLvs7odK2a/HG+UQW5Gd2SljZytk6MUNhKsleVE5WCm8IzaLec1/NT2duwUkcoYvA==",
       "requires": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
         "@web3-storage/gateway-lib": "^3.1.1",
-        "cardex": "^1.0.1",
+        "cardex": "^2.0.1",
         "chardet": "^1.5.0",
         "dagula": "^7.0.0",
         "magic-bytes.js": "^1.0.12",
@@ -3120,9 +3120,9 @@
       "dev": true
     },
     "node_modules/cardex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-1.0.1.tgz",
-      "integrity": "sha512-qtEBmfCPU9alMle+ZEJuBCO9OOPQmgowRzYcumxX0mI9aU0/GEvI6riZF6P2ouT4JH6yM3aYbDaqcoVuV3UVQw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.0.1.tgz",
+      "integrity": "sha512-5aH7nX7u8v5hI7TMNiLKsX2ZK2bChzkdtWLl0x0geXuv6HgLSYudaRB5MANRfLlIPNPzZW91rRKHGmPDp/WiSw==",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",
@@ -3131,7 +3131,7 @@
         "varint": "^6.0.0"
       },
       "bin": {
-        "cardex": "bin.js"
+        "cardex": "src/bin.js"
       }
     },
     "node_modules/cbor": {
@@ -12338,9 +12338,9 @@
       }
     },
     "cardex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-1.0.1.tgz",
-      "integrity": "sha512-qtEBmfCPU9alMle+ZEJuBCO9OOPQmgowRzYcumxX0mI9aU0/GEvI6riZF6P2ouT4JH6yM3aYbDaqcoVuV3UVQw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.0.1.tgz",
+      "integrity": "sha512-5aH7nX7u8v5hI7TMNiLKsX2ZK2bChzkdtWLl0x0geXuv6HgLSYudaRB5MANRfLlIPNPzZW91rRKHGmPDp/WiSw==",
       "requires": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
     "@web3-storage/gateway-lib": "^3.1.1",
-    "cardex": "^2.0.1",
+    "cardex": "^2.1.0",
     "chardet": "^1.5.0",
     "dagula": "^7.0.0",
     "magic-bytes.js": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
     "@web3-storage/gateway-lib": "^3.1.1",
-    "cardex": "^1.0.1",
+    "cardex": "^2.0.1",
     "chardet": "^1.5.0",
     "dagula": "^7.0.0",
     "magic-bytes.js": "^1.0.12",

--- a/src/lib/blockstore.js
+++ b/src/lib/blockstore.js
@@ -1,13 +1,12 @@
 import { readBlockHead, asyncIterableReader } from '@ipld/car/decoder'
 import { base58btc } from 'multiformats/bases/base58'
 import defer from 'p-defer'
-import { toIterable } from '@web3-storage/gateway-lib/util'
 import { MultiCarIndex, StreamingCarIndex } from './car-index.js'
 import { OrderedCarBlockBatcher } from './block-batch.js'
 
 /**
  * @typedef {import('multiformats').CID} CID
- * @typedef {import('cardex/mh-index-sorted').IndexEntry} IndexEntry
+ * @typedef {import('cardex/api').IndexItem} IndexEntry
  * @typedef {string} MultihashString
  * @typedef {import('dagula').Block} Block
  * @typedef {import('../bindings').R2Bucket} R2Bucket

--- a/src/lib/blockstore.js
+++ b/src/lib/blockstore.js
@@ -31,14 +31,14 @@ export class R2Blockstore {
     this._dataBucket = dataBucket
     this._idx = new MultiCarIndex()
     for (const carCid of carCids) {
-      this._idx.addIndex(carCid, new StreamingCarIndex((async function * () {
+      this._idx.addIndex(carCid, new StreamingCarIndex(async () => {
         const idxPath = `${carCid}/${carCid}.car.idx`
         const idxObj = await indexBucket.get(idxPath)
         if (!idxObj) {
           throw Object.assign(new Error(`index not found: ${carCid}`), { code: 'ERR_MISSING_INDEX' })
         }
-        yield * toIterable(idxObj.body)
-      })()))
+        return idxObj.body
+      }))
     }
   }
 

--- a/src/lib/car-index.js
+++ b/src/lib/car-index.js
@@ -2,10 +2,8 @@ import { base58btc } from 'multiformats/bases/base58'
 import { MultihashIndexSortedReader } from 'cardex'
 import defer from 'p-defer'
 
-import { CID } from 'multiformats'
-import * as raw from 'multiformats/codecs/raw'
-
 /**
+ * @typedef {import('multiformats').CID} CID
  * @typedef {import('cardex/multihash-index-sorted/api').MultihashIndexItem} IndexEntry
  * @typedef {string} MultihashString
  * @typedef {{ get: (c: CID) => Promise<IndexEntry|undefined> }} CarIndex

--- a/src/lib/car-index.js
+++ b/src/lib/car-index.js
@@ -2,9 +2,11 @@ import { base58btc } from 'multiformats/bases/base58'
 import { MultihashIndexSortedReader } from 'cardex'
 import defer from 'p-defer'
 
+import { CID } from 'multiformats'
+import * as raw from 'multiformats/codecs/raw'
+
 /**
- * @typedef {import('multiformats').CID} CID
- * @typedef {import('cardex/mh-index-sorted').IndexEntry} IndexEntry
+ * @typedef {import('cardex/multihash-index-sorted/api').MultihashIndexItem} IndexEntry
  * @typedef {string} MultihashString
  * @typedef {{ get: (c: CID) => Promise<IndexEntry|undefined> }} CarIndex
  */
@@ -67,19 +69,21 @@ export class StreamingCarIndex {
   /** @type {Error?} */
   #buildError = null
 
-  /** @param {AsyncIterable<Uint8Array>} stream */
-  constructor (stream) {
-    this.#buildIndex(stream)
+  /** @param {() => Promise<ReadableStream<Uint8Array>>} fetchIndex */
+  constructor (fetchIndex) {
+    this.#buildIndex(fetchIndex)
   }
 
-  /** @param {AsyncIterable<Uint8Array>} stream */
-  async #buildIndex (stream) {
-    console.log('building index')
+  /** @param {() => Promise<ReadableStream<Uint8Array>>} fetchIndex */
+  async #buildIndex (fetchIndex) {
     this.#building = true
     try {
-      const idxReader = MultihashIndexSortedReader.fromIterable(stream)
-      for await (const entry of idxReader.entries()) {
-        if (!entry.multihash) throw new Error('missing entry multihash')
+      const stream = await fetchIndex()
+      const idxReader = MultihashIndexSortedReader.createReader({ reader: stream.getReader() })
+      while (true) {
+        const { done, value: entry } = await idxReader.read()
+        if (done) break
+
         const key = mhToKey(entry.multihash.bytes)
 
         // set this value in the index so any future requests for this key get
@@ -100,7 +104,7 @@ export class StreamingCarIndex {
 
       // signal we are done building the index
       this.#building = false
-      console.log('finished building index')
+
       // resolve any keys in the promised index as "not found" - we're done
       // building so they will not get resolved otherwise.
       for (const [key, promises] of this.#promisedIdx.entries()) {

--- a/src/lib/car-index.js
+++ b/src/lib/car-index.js
@@ -1,5 +1,5 @@
 import { base58btc } from 'multiformats/bases/base58'
-import { MultihashIndexSortedReader } from 'cardex'
+import { UniversalReader } from 'cardex/universal'
 import defer from 'p-defer'
 
 /**
@@ -77,11 +77,12 @@ export class StreamingCarIndex {
     this.#building = true
     try {
       const stream = await fetchIndex()
-      const idxReader = MultihashIndexSortedReader.createReader({ reader: stream.getReader() })
+      const idxReader = UniversalReader.createReader({ reader: stream.getReader() })
       while (true) {
-        const { done, value: entry } = await idxReader.read()
+        const { done, value } = await idxReader.read()
         if (done) break
 
+        const entry = /** @type {IndexEntry} */(value)
         const key = mhToKey(entry.multihash.bytes)
 
         // set this value in the index so any future requests for this key get

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,3 +1,4 @@
+/* global TransformStream */
 import { pack } from 'ipfs-car/pack'
 import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'


### PR DESCRIPTION
Upgrade to the new version of cardex, which has a web stream-y API similar to https://github.com/ipld/js-unixfs.