### PR TITLE
feat: use rollup indexes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
         "@web3-storage/gateway-lib": "^3.1.1",
-        "cardex": "^2.1.0",
+        "cardex": "^2.2.0",
         "chardet": "^1.5.0",
         "dagula": "^7.0.0",
         "magic-bytes.js": "^1.0.12",
@@ -3120,9 +3120,9 @@
       "dev": true
     },
     "node_modules/cardex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.1.0.tgz",
-      "integrity": "sha512-rEo9iXU3C+V6iUqnB7PWdbLvs7odK2a/HG+UQW5Gd2SljZytk6MUNhKsleVE5WCm8IzaLec1/NT2duwUkcoYvA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.0.tgz",
+      "integrity": "sha512-YoCw1bSYSWoEGMTiqAkggVSBbDt+EiEd89qNKGzmIdoTd9vmksG6hjFo7dvyJvReb6QQrBvb7BrqHxqeX92C2g==",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",
@@ -12338,9 +12338,9 @@
       }
     },
     "cardex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.1.0.tgz",
-      "integrity": "sha512-rEo9iXU3C+V6iUqnB7PWdbLvs7odK2a/HG+UQW5Gd2SljZytk6MUNhKsleVE5WCm8IzaLec1/NT2duwUkcoYvA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.0.tgz",
+      "integrity": "sha512-YoCw1bSYSWoEGMTiqAkggVSBbDt+EiEd89qNKGzmIdoTd9vmksG6hjFo7dvyJvReb6QQrBvb7BrqHxqeX92C2g==",
       "requires": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
-        "@web3-storage/gateway-lib": "^3.1.1",
+        "@web3-storage/gateway-lib": "^3.2.2",
         "cardex": "^2.2.0",
         "chardet": "^1.5.0",
         "dagula": "^7.0.0",
@@ -2323,9 +2323,9 @@
       }
     },
     "node_modules/@web3-storage/gateway-lib": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-3.1.1.tgz",
-      "integrity": "sha512-zuUiouz1QHuXyjTsq1INKRVKZnuhEj5FPCeYNdhjTMT/twUS8QJG7JBJnNgo2Pyf6WPQDO34dzVu+cF97KseBA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-3.2.2.tgz",
+      "integrity": "sha512-OeoobrsJjg7HKTh0cpVL7MWaylUCkir52R7m20oI/QGxrtz2D+1EwwzyAaLso/HsUzcKYWwH5BlDepRExPzQmQ==",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "@web3-storage/handlebars": "^1.0.0",
@@ -3123,7 +3123,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.0.tgz",
       "integrity": "sha512-YoCw1bSYSWoEGMTiqAkggVSBbDt+EiEd89qNKGzmIdoTd9vmksG6hjFo7dvyJvReb6QQrBvb7BrqHxqeX92C2g==",
-
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",
@@ -11718,9 +11717,9 @@
       }
     },
     "@web3-storage/gateway-lib": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-3.1.1.tgz",
-      "integrity": "sha512-zuUiouz1QHuXyjTsq1INKRVKZnuhEj5FPCeYNdhjTMT/twUS8QJG7JBJnNgo2Pyf6WPQDO34dzVu+cF97KseBA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@web3-storage/gateway-lib/-/gateway-lib-3.2.2.tgz",
+      "integrity": "sha512-OeoobrsJjg7HKTh0cpVL7MWaylUCkir52R7m20oI/QGxrtz2D+1EwwzyAaLso/HsUzcKYWwH5BlDepRExPzQmQ==",
       "requires": {
         "@ipld/car": "^5.1.0",
         "@web3-storage/handlebars": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
         "@web3-storage/gateway-lib": "^3.1.1",
-        "cardex": "^2.0.1",
+        "cardex": "^2.1.0",
         "chardet": "^1.5.0",
         "dagula": "^7.0.0",
         "magic-bytes.js": "^1.0.12",
@@ -3120,9 +3120,9 @@
       "dev": true
     },
     "node_modules/cardex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.0.1.tgz",
-      "integrity": "sha512-5aH7nX7u8v5hI7TMNiLKsX2ZK2bChzkdtWLl0x0geXuv6HgLSYudaRB5MANRfLlIPNPzZW91rRKHGmPDp/WiSw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.1.0.tgz",
+      "integrity": "sha512-rEo9iXU3C+V6iUqnB7PWdbLvs7odK2a/HG+UQW5Gd2SljZytk6MUNhKsleVE5WCm8IzaLec1/NT2duwUkcoYvA==",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",
@@ -12338,9 +12338,9 @@
       }
     },
     "cardex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.0.1.tgz",
-      "integrity": "sha512-5aH7nX7u8v5hI7TMNiLKsX2ZK2bChzkdtWLl0x0geXuv6HgLSYudaRB5MANRfLlIPNPzZW91rRKHGmPDp/WiSw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.1.0.tgz",
+      "integrity": "sha512-rEo9iXU3C+V6iUqnB7PWdbLvs7odK2a/HG+UQW5Gd2SljZytk6MUNhKsleVE5WCm8IzaLec1/NT2duwUkcoYvA==",
       "requires": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
         "@web3-storage/gateway-lib": "^3.1.1",
-        "cardex": "^1.0.1",
+        "cardex": "^2.0.1",
         "chardet": "^1.5.0",
         "dagula": "^7.0.0",
         "magic-bytes.js": "^1.0.12",
@@ -3120,9 +3120,9 @@
       "dev": true
     },
     "node_modules/cardex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-1.0.1.tgz",
-      "integrity": "sha512-qtEBmfCPU9alMle+ZEJuBCO9OOPQmgowRzYcumxX0mI9aU0/GEvI6riZF6P2ouT4JH6yM3aYbDaqcoVuV3UVQw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.0.1.tgz",
+      "integrity": "sha512-5aH7nX7u8v5hI7TMNiLKsX2ZK2bChzkdtWLl0x0geXuv6HgLSYudaRB5MANRfLlIPNPzZW91rRKHGmPDp/WiSw==",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",
@@ -3131,7 +3131,7 @@
         "varint": "^6.0.0"
       },
       "bin": {
-        "cardex": "bin.js"
+        "cardex": "src/bin.js"
       }
     },
     "node_modules/cbor": {
@@ -12338,9 +12338,9 @@
       }
     },
     "cardex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-1.0.1.tgz",
-      "integrity": "sha512-qtEBmfCPU9alMle+ZEJuBCO9OOPQmgowRzYcumxX0mI9aU0/GEvI6riZF6P2ouT4JH6yM3aYbDaqcoVuV3UVQw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.0.1.tgz",
+      "integrity": "sha512-5aH7nX7u8v5hI7TMNiLKsX2ZK2bChzkdtWLl0x0geXuv6HgLSYudaRB5MANRfLlIPNPzZW91rRKHGmPDp/WiSw==",
       "requires": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
     "@web3-storage/gateway-lib": "^3.1.1",
-    "cardex": "^2.0.1",
+    "cardex": "^2.1.0",
     "chardet": "^1.5.0",
     "dagula": "^7.0.0",
     "magic-bytes.js": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "npm run dev",
-    "dev": "npm run build:debug && miniflare dist/worker.mjs --watch --debug -m --r2-persist",
+    "dev": "npm run build:debug && miniflare dist/worker.mjs --watch --debug -m --r2-persist --global-async-io --global-timers",
     "build": "esbuild --bundle src/index.js --format=esm --sourcemap --minify --outfile=dist/worker.mjs",
     "build:debug": "esbuild --bundle src/index.js --format=esm --outfile=dist/worker.mjs",
     "test": "npm run build:debug && node --test --experimental-vm-modules",
@@ -27,7 +27,7 @@
     "@ipld/dag-cbor": "^9.0.0",
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
-    "@web3-storage/gateway-lib": "^3.1.1",
+    "@web3-storage/gateway-lib": "^3.2.2",
     "cardex": "^2.2.0",
     "chardet": "^1.5.0",
     "dagula": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
     "@web3-storage/gateway-lib": "^3.1.1",
-    "cardex": "^2.1.0",
+    "cardex": "^2.2.0",
     "chardet": "^1.5.0",
     "dagula": "^7.0.0",
     "magic-bytes.js": "^1.0.12",
@@ -46,5 +46,10 @@
     "miniflare": "^2.9.0",
     "standard": "^17.0.0",
     "uint8arrays": "^4.0.3"
+  },
+  "standard": {
+    "ignore": [
+      "*.ts"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
     "@web3-storage/gateway-lib": "^3.1.1",
-    "cardex": "^1.0.1",
+    "cardex": "^2.0.1",
     "chardet": "^1.5.0",
     "dagula": "^7.0.0",
     "magic-bytes.js": "^1.0.12",

--- a/scripts/r2-put.js
+++ b/scripts/r2-put.js
@@ -2,7 +2,7 @@
  * Puts data to the local persisted Miniflare R2 buckets.
  *
  * Usage:
- *   node scripts/r2-put.js test.jpg --no-wrap
+ *   node scripts/r2-put.js test.jpg --no-wrap --no-rollup
  */
 import { R2Bucket } from '@miniflare/r2'
 import { FileStorage } from '@miniflare/storage-file'
@@ -19,6 +19,9 @@ const input = files.map(f => ({ path: f.name, content: f.stream() }))
 const wrapWithDirectory = process.argv.every(p => p !== '--no-wrap')
 
 const { dataCid, carCids } = await builder.add(input, { wrapWithDirectory })
+
+const rollup = process.argv.every(p => p !== '--no-rollup')
+if (rollup) await builder.rollup(dataCid, carCids)
 
 console.log(`Data CID:\n${dataCid}`)
 console.log(`CAR CIDs:\n${carCids.join('\n')}`)

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,5 +1,6 @@
-import type { CID } from 'multiformats/cid'
+import type { Link } from 'multiformats/link'
 import type { Context } from '@web3-storage/gateway-lib'
+import type { CARLink } from 'cardex/api'
 import type { MemoryBudget } from './lib/mem-budget'
 
 export {}
@@ -12,8 +13,21 @@ export interface Environment {
   MAX_SHARDS: string
 }
 
-export interface CarCidsContext extends Context {
-  carCids: CID[]
+export interface IndexSource {
+  /** Bucket this index can be found in */
+  bucket: R2Bucket
+  /** Bucket key for the source */
+  key: string
+  /**
+   * Origin CAR CID the index source applies to. Will be undefined if the index
+   * source is a multi-index index, which specifies origin CAR CIDs within the
+   * index.
+   */
+  origin?: CARLink
+}
+
+export interface IndexSourcesContext extends Context {
+  indexSources: IndexSource[]
 }
 
 export interface R2GetOptions {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import {
 } from '@web3-storage/gateway-lib/handlers'
 import {
   withDagula,
-  withCarCids,
+  withIndexSources,
   withUnsupportedFeaturesHandler,
   withVersionHeader
 } from './middleware.js'
@@ -24,7 +24,6 @@ import {
 /**
  * @typedef {import('./bindings').Environment} Environment
  * @typedef {import('@web3-storage/gateway-lib').IpfsUrlContext} IpfsUrlContext
- * @typedef {import('./bindings').CarCidsContext} CarCidsContext
  * @typedef {import('@web3-storage/gateway-lib').DagulaContext} DagulaContext
  */
 
@@ -41,7 +40,7 @@ export default {
       withUnsupportedFeaturesHandler,
       withHttpGet,
       withParsedIpfsUrl,
-      withCarCids,
+      withIndexSources,
       withDagula,
       withFixedLengthStream
     )
@@ -49,7 +48,7 @@ export default {
   }
 }
 
-/** @type {import('@web3-storage/gateway-lib').Handler<DagulaContext & CarCidsContext & IpfsUrlContext, Environment>} */
+/** @type {import('@web3-storage/gateway-lib').Handler<DagulaContext & IpfsUrlContext, Environment>} */
 async function handler (request, env, ctx) {
   const { headers } = request
   const { searchParams } = ctx

--- a/src/lib/block-batch.js
+++ b/src/lib/block-batch.js
@@ -4,7 +4,7 @@ const MAX_BATCH_SIZE = 10
 /**
  * @typedef {import('multiformats').UnknownLink} UnknownLink
  * @typedef {{ carCid: import('cardex/api').CARLink, blockCid: UnknownLink, offset: number }} BatchItem
- * @typedef {{ add: (i: BatchItem) => void, next: () => BatchItem[] }} BlockBatcher
+ * @typedef {{ add: (i: BatchItem) => void, remove: (cid: UnknownLink) => void, next: () => BatchItem[] }} BlockBatcher
  */
 
 /**
@@ -19,6 +19,11 @@ export class OrderedCarBlockBatcher {
   /** @param {BatchItem} item */
   add (item) {
     this.#queue.push(item)
+  }
+
+  /** @param {UnknownLink} cid */
+  remove (cid) {
+    this.#queue = this.#queue.filter(item => item.blockCid.toString() !== cid.toString())
   }
 
   next () {

--- a/src/lib/block-batch.js
+++ b/src/lib/block-batch.js
@@ -2,8 +2,8 @@ const MAX_BYTES_BETWEEN = 1024 * 1024 * 2
 const MAX_BATCH_SIZE = 10
 
 /**
- * @typedef {import('multiformats').CID} CID
- * @typedef {{ carCid: CID, blockCid: CID, offset: number }} BatchItem
+ * @typedef {import('multiformats').UnknownLink} UnknownLink
+ * @typedef {{ carCid: import('cardex/api').CARLink, blockCid: UnknownLink, offset: number }} BatchItem
  * @typedef {{ add: (i: BatchItem) => void, next: () => BatchItem[] }} BlockBatcher
  */
 

--- a/src/lib/blockstore.js
+++ b/src/lib/blockstore.js
@@ -1,13 +1,12 @@
 import { readBlockHead, asyncIterableReader } from '@ipld/car/decoder'
 import { base58btc } from 'multiformats/bases/base58'
 import defer from 'p-defer'
-import { toIterable } from '@web3-storage/gateway-lib/util'
 import { MultiCarIndex, StreamingCarIndex } from './car-index.js'
 import { OrderedCarBlockBatcher } from './block-batch.js'
 
 /**
  * @typedef {import('multiformats').CID} CID
- * @typedef {import('cardex/mh-index-sorted').IndexEntry} IndexEntry
+ * @typedef {import('cardex/api').IndexItem} IndexEntry
  * @typedef {string} MultihashString
  * @typedef {import('dagula').Block} Block
  * @typedef {import('../bindings').R2Bucket} R2Bucket

--- a/src/lib/blockstore.js
+++ b/src/lib/blockstore.js
@@ -27,7 +27,7 @@ export class R2Blockstore {
    */
   constructor (dataBucket, indexSources) {
     this._dataBucket = dataBucket
-    this._idx = new MultiCarIndex(
+    this._idx = new MultiCarIndex()
     for (const src of indexSources) {
       this._idx.addIndex(new StreamingCarIndex(src))
     }

--- a/src/lib/blockstore.js
+++ b/src/lib/blockstore.js
@@ -31,14 +31,14 @@ export class R2Blockstore {
     this._dataBucket = dataBucket
     this._idx = new MultiCarIndex()
     for (const carCid of carCids) {
-      this._idx.addIndex(carCid, new StreamingCarIndex((async function * () {
+      this._idx.addIndex(carCid, new StreamingCarIndex(async () => {
         const idxPath = `${carCid}/${carCid}.car.idx`
         const idxObj = await indexBucket.get(idxPath)
         if (!idxObj) {
           throw Object.assign(new Error(`index not found: ${carCid}`), { code: 'ERR_MISSING_INDEX' })
         }
-        yield * toIterable(idxObj.body)
-      })()))
+        return idxObj.body
+      }))
     }
   }
 

--- a/src/lib/blockstore.js
+++ b/src/lib/blockstore.js
@@ -179,6 +179,8 @@ export class BatchingR2Blockstore extends R2Blockstore {
             }
             blocks.forEach(b => b.resolve(block))
             pendingBlocks.delete(key)
+            // remove from batcher if queued to be read
+            batcher.remove(blockHeader.cid)
           }
         } catch {
           break

--- a/src/lib/car-index.js
+++ b/src/lib/car-index.js
@@ -2,10 +2,8 @@ import { base58btc } from 'multiformats/bases/base58'
 import { MultihashIndexSortedReader } from 'cardex'
 import defer from 'p-defer'
 
-import { CID } from 'multiformats'
-import * as raw from 'multiformats/codecs/raw'
-
 /**
+ * @typedef {import('multiformats').CID} CID
  * @typedef {import('cardex/multihash-index-sorted/api').MultihashIndexItem} IndexEntry
  * @typedef {string} MultihashString
  * @typedef {{ get: (c: CID) => Promise<IndexEntry|undefined> }} CarIndex

--- a/src/lib/car-index.js
+++ b/src/lib/car-index.js
@@ -2,9 +2,11 @@ import { base58btc } from 'multiformats/bases/base58'
 import { MultihashIndexSortedReader } from 'cardex'
 import defer from 'p-defer'
 
+import { CID } from 'multiformats'
+import * as raw from 'multiformats/codecs/raw'
+
 /**
- * @typedef {import('multiformats').CID} CID
- * @typedef {import('cardex/mh-index-sorted').IndexEntry} IndexEntry
+ * @typedef {import('cardex/multihash-index-sorted/api').MultihashIndexItem} IndexEntry
  * @typedef {string} MultihashString
  * @typedef {{ get: (c: CID) => Promise<IndexEntry|undefined> }} CarIndex
  */
@@ -67,19 +69,21 @@ export class StreamingCarIndex {
   /** @type {Error?} */
   #buildError = null
 
-  /** @param {AsyncIterable<Uint8Array>} stream */
-  constructor (stream) {
-    this.#buildIndex(stream)
+  /** @param {() => Promise<ReadableStream<Uint8Array>>} fetchIndex */
+  constructor (fetchIndex) {
+    this.#buildIndex(fetchIndex)
   }
 
-  /** @param {AsyncIterable<Uint8Array>} stream */
-  async #buildIndex (stream) {
-    console.log('building index')
+  /** @param {() => Promise<ReadableStream<Uint8Array>>} fetchIndex */
+  async #buildIndex (fetchIndex) {
     this.#building = true
     try {
-      const idxReader = MultihashIndexSortedReader.fromIterable(stream)
-      for await (const entry of idxReader.entries()) {
-        if (!entry.multihash) throw new Error('missing entry multihash')
+      const stream = await fetchIndex()
+      const idxReader = MultihashIndexSortedReader.createReader({ reader: stream.getReader() })
+      while (true) {
+        const { done, value: entry } = await idxReader.read()
+        if (done) break
+
         const key = mhToKey(entry.multihash.bytes)
 
         // set this value in the index so any future requests for this key get
@@ -100,7 +104,7 @@ export class StreamingCarIndex {
 
       // signal we are done building the index
       this.#building = false
-      console.log('finished building index')
+
       // resolve any keys in the promised index as "not found" - we're done
       // building so they will not get resolved otherwise.
       for (const [key, promises] of this.#promisedIdx.entries()) {

--- a/src/lib/car-index.js
+++ b/src/lib/car-index.js
@@ -1,5 +1,5 @@
 import { base58btc } from 'multiformats/bases/base58'
-import { MultihashIndexSortedReader } from 'cardex'
+import { UniversalReader } from 'cardex/universal'
 import defer from 'p-defer'
 
 /**
@@ -77,11 +77,12 @@ export class StreamingCarIndex {
     this.#building = true
     try {
       const stream = await fetchIndex()
-      const idxReader = MultihashIndexSortedReader.createReader({ reader: stream.getReader() })
+      const idxReader = UniversalReader.createReader({ reader: stream.getReader() })
       while (true) {
-        const { done, value: entry } = await idxReader.read()
+        const { done, value } = await idxReader.read()
         if (done) break
 
+        const entry = /** @type {IndexEntry} */(value)
         const key = mhToKey(entry.multihash.bytes)
 
         // set this value in the index so any future requests for this key get

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -11,7 +11,7 @@ const CAR_CODE = 0x0202
 /**
  * @typedef {import('./bindings').Environment} Environment
  * @typedef {import('@web3-storage/gateway-lib').IpfsUrlContext} IpfsUrlContext
- * @typedef {import('./bindings').CarCidsContext} CarCidsContext
+ * @typedef {import('./bindings').IndexSourcesContext} IndexSourcesContext
  * @typedef {import('@web3-storage/gateway-lib').DagulaContext} DagulaContext
  */
 
@@ -32,89 +32,100 @@ export function withUnsupportedFeaturesHandler (handler) {
 }
 
 /**
- * Extracts CAR CIDs search params from the URL querystring or DUDEWHERE bucket.
- * @type {import('@web3-storage/gateway-lib').Middleware<CarCidsContext & IpfsUrlContext, IpfsUrlContext, Environment>}
+ * Extracts a set of index sources from search params from the URL querystring
+ * or DUDEWHERE bucket.
+ * @type {import('@web3-storage/gateway-lib').Middleware<IndexSourcesContext & IpfsUrlContext, IpfsUrlContext, Environment>}
  */
-export function withCarCids (handler) {
+export function withIndexSources (handler) {
   return async (request, env, ctx) => {
     if (!ctx.dataCid) throw new Error('missing data CID')
     if (!ctx.searchParams) throw new Error('missing URL search params')
 
-    // Cloudflare currently sets a limit of 3300 sub-requests within the worker context
-    // If we have a given root CID splitted across hundreds of CARs, freeway will hit
-    // the sub-requests limit and not serve content anyway
+    // Cloudflare currently sets a limit of 3300 sub-requests within the worker
+    // context. If we have a given root CID split across hundreds of CARs,
+    // freeway will hit the sub-requests limit and not serve the content.
     const maxShards = env.MAX_SHARDS ? parseInt(env.MAX_SHARDS) : 825
 
-    const carCids = ctx.searchParams.getAll('origin').flatMap(str => {
-      return str.split(',')
-        .reduce((/** @type {import('multiformats').CID[]} */cids, str) => {
-          try {
-            const cid = parseCid(str)
+    /** @type {import('./bindings').IndexSource[]} */
+    const indexSources = ctx.searchParams
+      .getAll('origin')
+      .flatMap(str => {
+        return str.split(',')
+          .reduce((cids, str) => {
+            const cid = /** @type {import('cardex/api').CARLink} */(parseCid(str))
             if (cid.code !== CAR_CODE) {
               throw new HttpError(`not a CAR CID: ${cid}`, { status: 400 })
             }
             cids.push(cid)
-          } catch {}
-          return cids
-        }, [])
-    })
+            return cids
+          }, /** @type {import('cardex/api').CARLink[]} */([]))
+      })
+      .map(cid => ({ origin: cid, bucket: env.SATNAV, key: `${cid}/${cid}.car.idx` }))
 
     // if origins were not specified or invalid
-    if (!carCids.length) {
+    if (!indexSources.length) {
       /** @type {string|undefined} */
       let cursor
       while (true) {
         const results = await env.DUDEWHERE.list({ prefix: `${ctx.dataCid}/`, cursor })
         if (!results || !results.objects.length) break
-        carCids.push(...results.objects.map(o => parseCid(o.key.split('/')[1])))
 
-        if (carCids.length > maxShards) {
+        // if the first encountered item is a index rollup, use it
+        if (!cursor && results.objects[0].key.endsWith('rollup.idx')) {
+          indexSources.push({ bucket: env.DUDEWHERE, key: results.objects[0].key })
+          break
+        }
+
+        indexSources.push(...results.objects.map(o => {
+          const cid = /** @type {import('cardex/api').CARLink} */(parseCid(o.key.split('/')[1]))
+          const key = `${cid}/${cid}.car.idx`
+          return { origin: cid, bucket: env.SATNAV, key }
+        }))
+
+        if (indexSources.length > maxShards) {
           throw new HttpError('request exceeds maximum DAG shards', { status: 501 })
         }
 
         if (!results.truncated) break
         cursor = results.cursor
       }
-      console.log(`dude where's my CAR? ${ctx.dataCid} => ${carCids}`)
-    } else {
-      if (carCids.length > maxShards) {
-        throw new HttpError('request exceeds maximum DAG shards', { status: 501 })
-      }
+      console.log(`${ctx.dataCid} => ${indexSources.length} index sources`)
     }
 
-    if (!carCids.length) {
-      throw new HttpError('missing origin CAR CID(s)', { status: 404 })
+    if (!indexSources.length) {
+      throw new HttpError('missing index', { status: 404 })
     }
 
-    return handler(request, env, { ...ctx, carCids })
+    return handler(request, env, { ...ctx, indexSources })
   }
 }
 
 /**
  * Creates a dagula instance backed by the R2 blockstore.
- * @type {import('@web3-storage/gateway-lib').Middleware<DagulaContext & CarCidsContext & IpfsUrlContext, CarCidsContext & IpfsUrlContext, Environment>}
+ * @type {import('@web3-storage/gateway-lib').Middleware<DagulaContext & IndexSourcesContext & IpfsUrlContext, IndexSourcesContext & IpfsUrlContext, Environment>}
  */
 export function withDagula (handler) {
   return async (request, env, ctx) => {
-    const { carCids, searchParams } = ctx
-    if (!carCids) throw new Error('missing CAR CIDs in context')
+    const { indexSources, searchParams } = ctx
+    if (!indexSources) throw new Error('missing CAR CIDs in context')
     if (!searchParams) throw new Error('missing URL search params in context')
 
     /** @type {import('dagula').Blockstore?} */
     let blockstore = null
-    if (carCids.length === 1) {
-      const carPath = `${carCids[0]}/${carCids[0]}.car`
+    if (indexSources.length === 1 && indexSources[0].origin != null) {
+      const carPath = `${indexSources[0].origin}/${indexSources[0].origin}.car`
       const headObj = await env.CARPARK.head(carPath)
       if (!headObj) throw new HttpError('CAR not found', { status: 404 })
       if (headObj.size < MAX_CAR_BYTES_IN_MEMORY) {
         const obj = await env.CARPARK.get(carPath)
         if (!obj) throw new HttpError('CAR not found', { status: 404 })
+        // @ts-expect-error old multiformats in js-car
         blockstore = await CarReader.fromIterable(toIterable(obj.body))
       }
     }
 
     if (!blockstore) {
-      blockstore = new BatchingR2Blockstore(env.CARPARK, env.SATNAV, carCids)
+      blockstore = new BatchingR2Blockstore(env.CARPARK, indexSources)
     }
 
     const dagula = new Dagula(blockstore)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,3 +1,4 @@
+/* global TransformStream */
 import { pack } from 'ipfs-car/pack'
 import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -102,8 +102,6 @@ describe('freeway', () => {
     const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
     const { dataCid, carCids } = await builder.add(input)
 
-    await builder.rollup(dataCid, carCids)
-
     // remove the the CAR CIDs from DUDEWHERE so that only the rollup index can
     // be used to satisfy the request.
     const bucket = await miniflare.getR2Bucket('DUDEWHERE')
@@ -111,10 +109,17 @@ describe('freeway', () => {
       await bucket.delete(`${dataCid}/${cid}`)
     }
 
-    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
-    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+    // should NOT be able to serve this CID now
+    const res0 = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+    assert.equal(res0.status, 404)
 
-    const output = new Uint8Array(await res.arrayBuffer())
+    // generate the rollup index
+    await builder.rollup(dataCid, carCids)
+
+    const res1 = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+    if (!res1.ok) assert.fail(`unexpected response: ${await res1.text()}`)
+
+    const output = new Uint8Array(await res1.arrayBuffer())
     assert(equals(input[0].content, output))
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -97,4 +97,17 @@ describe('freeway', () => {
     const output = new Uint8Array(await res.arrayBuffer())
     assert.doesNotReject(CarReader.fromBytes(output))
   })
+
+  it('should use a rollup index', async () => {
+    const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
+    const { dataCid, carCids } = await builder.add(input)
+
+    await builder.rollup(dataCid, carCids)
+
+    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+
+    const output = new Uint8Array(await res.arrayBuffer())
+    assert(equals(input[0].content, output))
+  })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -104,6 +104,13 @@ describe('freeway', () => {
 
     await builder.rollup(dataCid, carCids)
 
+    // remove the the CAR CIDs from DUDEWHERE so that only the rollup index can
+    // be used to satisfy the request.
+    const bucket = await miniflare.getR2Bucket('DUDEWHERE')
+    for (const cid of carCids) {
+      bucket.delete(`${dataCid}/${cid}`)
+    }
+
     const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
     if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -108,7 +108,7 @@ describe('freeway', () => {
     // be used to satisfy the request.
     const bucket = await miniflare.getR2Bucket('DUDEWHERE')
     for (const cid of carCids) {
-      bucket.delete(`${dataCid}/${cid}`)
+      await bucket.delete(`${dataCid}/${cid}`)
     }
 
     const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)


### PR DESCRIPTION
This PR allows Freeway to use rollup indexes. Rollups are multi-index indexes (see https://github.com/alanshaw/cardex#multi-index-index) that specify which blocks are in which CAR file(s) for a given DAG.

Freeway checks DUDEWHERE for a rollup index at `bafyROOT/.rollup.idx`. If it finds one, it'll use it (and no other indexes) to obtain index informations for all the blocks.