### PR TITLE
feat: use blockly indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The freeway currently works with the following R2 buckets:
 * `CARPARK` - CAR file storage area. Key format `<CAR_CID>/<CAR_CID>.car`
 * `SATNAV` - Indexes of block offsets within CARs. Key format `<CAR_CID>/<CAR_CID>.car.idx`, index format [`MultihashIndexSorted`](https://ipld.io/specs/transport/car/carv2/#format-0x0401-multihashindexsorted).
 * `DUDEWHERE` - Mapping of root data CIDs to CAR CID(s). Key format `<DATA_CID>/<CAR_CID>`.
-* `BLOCKLY` - Block+link [multi-indexes](https://github.com/web3-storage/specs/blob/73c386b999cf30fb648987ff9dce0516c1d91137/CARv2%20MultiIndex.md). Key format `<BLOCK_CID>/<BLOCK_CID>.idx`.
+* `BLOCKLY` - Block+link [multi-indexes](https://github.com/web3-storage/specs/blob/73c386b999cf30fb648987ff9dce0516c1d91137/CARv2%20MultiIndex.md). Key format `<base58(BLOCK_MULTIHASH)>/<base58(BLOCK_MULTIHASH)>.idx`.
 
 How it works:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The freeway currently works with the following R2 buckets:
 * `CARPARK` - CAR file storage area. Key format `<CAR_CID>/<CAR_CID>.car`
 * `SATNAV` - Indexes of block offsets within CARs. Key format `<CAR_CID>/<CAR_CID>.car.idx`, index format [`MultihashIndexSorted`](https://ipld.io/specs/transport/car/carv2/#format-0x0401-multihashindexsorted).
 * `DUDEWHERE` - Mapping of root data CIDs to CAR CID(s). Key format `<DATA_CID>/<CAR_CID>`.
+* `BLOCKLY` - Block+link [multi-indexes](https://github.com/web3-storage/specs/blob/73c386b999cf30fb648987ff9dce0516c1d91137/CARv2%20MultiIndex.md). Key format `<BLOCK_CID>/<BLOCK_CID>.idx`.
 
 How it works:
 

--- a/READMOAR.md
+++ b/READMOAR.md
@@ -85,4 +85,4 @@ Advantages:
 
 * There are considerably fewer index read requests to make to serve a given DAG when each block index includes link data also.
 * Grouping indexing data by locality in this way facilitates batching range requests to CAR files to fetch multiple blocks in a single request.
-* If a DAG is built using the default web3.storage (and Filecoin) settings (1MiB chunks, 1,000 max children) we're able to service up to ~1GiB of data by reading just 1 blockly index.
+* If a DAG is built using the default web3.storage (and Filecoin) settings (1MiB chunks, 1,024 max children) we're able to service up to ~1GiB of data by reading just 1 blockly index (which would be roughly 37KiB).

--- a/READMOAR.md
+++ b/READMOAR.md
@@ -44,3 +44,45 @@ Observations:
 
 * TTFB depends on how much index data needs to be read before the root CID is encountered.
 * Effective block read batching, as we know all wanted block positions upfront.
+
+## Blockly (BLOCK LYnk) indexes
+
+Blockly is a collection of [multi-indexes](https://github.com/web3-storage/specs/blob/73c386b999cf30fb648987ff9dce0516c1d91137/CARv2%20MultiIndex.md) for individual blocks. Each index contains the CID of a CAR file the block may be found in and the block's byte offset. The index also contains the _same detail for any links_ the block has.
+
+Examples:
+
+```
+R
+L0 L1 L2
+```
+
+Since this DAG is very shallow, all of the indexing information can be found in the blockly index for `R`.
+
+1. Index request for `R`
+1. Block requests for `R` `L0` `L1` `L2` (possibly batched)
+
+```
+R
+L0       L1
+L2 L3    L4 L5
+```
+
+This DAG requires 3 requests to blockly indexes (`R`, `L0` and `L1`) to retrieve all the needed indexing information.
+
+1. Index request for `R`
+1. Block requests for `R` `L0` `L1` (possibly batched)
+1. Index requests for `L0` `L1`
+1. Block requests for `L2` `L3` `L4` `L5` (possibly batched)
+
+Note: there is scope for concurrency above, for example we can retrieve blocks for `R`, `L0` and `L1` at the same time as we request indexes for `L0`, `L1`.
+
+Trade offs:
+
+* There is some repeated information - the CID and offset for a given block can be found in it's own index but also in the indexes of any blocks that link to it.
+* IPLD codecs must be known in order to build the indexes for a DAG.
+
+Advantages:
+
+* There are considerably fewer index read requests to make to serve a given DAG when each block index includes link data also.
+* Grouping indexing data by locality in this way facilitates batching range requests to CAR files to fetch multiple blocks in a single request.
+* If a DAG is built using the default web3.storage (and Filecoin) settings (1MiB chunks, 1,000 max children) we're able to service up to ~1GiB of data by reading just 1 blockly index.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
         "@web3-storage/gateway-lib": "^3.2.2",
-        "cardex": "^2.2.1",
+        "cardex": "^2.2.2",
         "chardet": "^1.5.0",
         "dagula": "^7.0.0",
         "magic-bytes.js": "^1.0.12",
@@ -3121,9 +3121,9 @@
       "dev": true
     },
     "node_modules/cardex": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.1.tgz",
-      "integrity": "sha512-01wTySlsJTWMSFf0UmqwjXSh65v6ZC5P1oDqmqnTR5BF3bLHOpGHSovSTK6R3hxRCdkfJOCCmw8m0Rq5f9NuUg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.2.tgz",
+      "integrity": "sha512-ZB9YvbXYdb8+WtiWqb/1tl8eazwnQAPFaNRRWDPIAFQeKltkOlPnJre8tGSEACQ0scyvVmirMQlJBnT4/FsJMw==",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",
@@ -12343,9 +12343,9 @@
       }
     },
     "cardex": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.1.tgz",
-      "integrity": "sha512-01wTySlsJTWMSFf0UmqwjXSh65v6ZC5P1oDqmqnTR5BF3bLHOpGHSovSTK6R3hxRCdkfJOCCmw8m0Rq5f9NuUg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.2.tgz",
+      "integrity": "sha512-ZB9YvbXYdb8+WtiWqb/1tl8eazwnQAPFaNRRWDPIAFQeKltkOlPnJre8tGSEACQ0scyvVmirMQlJBnT4/FsJMw==",
       "requires": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
         "@web3-storage/gateway-lib": "^3.2.2",
-        "cardex": "^2.2.0",
+        "cardex": "^2.2.1",
         "chardet": "^1.5.0",
         "dagula": "^7.0.0",
         "magic-bytes.js": "^1.0.12",
@@ -29,7 +29,7 @@
         "esbuild": "^0.17.11",
         "files-from-path": "^0.2.6",
         "ipfs-car": "^0.9.2",
-        "miniflare": "^2.9.0",
+        "miniflare": "^2.14.0",
         "standard": "^17.0.0",
         "uint8arrays": "^4.0.3"
       }
@@ -1652,27 +1652,27 @@
       }
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.9.0.tgz",
-      "integrity": "sha512-lriPxUEva9TJ01vU9P7pI60s3SsFnb4apWkNwZ+D7CRqyXPipSbapY8BWI2FUIwkEG7xap6UhzeTS76NettCXQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.14.0.tgz",
+      "integrity": "sha512-0mz0OCzTegiX75uMURLJpDo3DaOCSx9M0gv7NMFWDbK/XrvjoENiBZiKu98UBM5fts0qtK19a+MfB4aT0uBCFg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.9.0.tgz",
-      "integrity": "sha512-gu8Z7NWNcYw6514/yOvajaj3GmebRucx+EEt3p1vKirO+gvFgKAt/puyUN3p7u8ZZmLuLF/B+wVnH3lj8BWKlg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.14.0.tgz",
+      "integrity": "sha512-6Wb0jTMqwI7GRGAhz9WOF8AONUsXXPmwu+Qhg+tnRWtQpJ3DYd5dku1N04L9L1R7np/mD8RrycLyCdg3hLZ3aA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.9.0",
+        "@miniflare/shared": "2.14.0",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -1680,20 +1680,20 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-QqSwF6oHvgrFvN5lnrLc6EEagFlZWW+UMU8QdrE8305cNGHrIOxKCA2nte4PVFZUVw/Ts13a0tVhUk3a2fAyxQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.14.0.tgz",
+      "integrity": "sha512-BjmV/ZDwsKvXnJntYHt3AQgzVKp/5ZzWPpYWoOnUSNxq6nnRCQyvFvjvBZKnhubcmJCLSqegvz0yHejMA90CTA==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/watcher": "2.9.0",
+        "@miniflare/queues": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/watcher": "2.14.0",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.9.1",
+        "undici": "5.20.0",
         "urlpattern-polyfill": "^4.0.3"
       },
       "engines": {
@@ -1701,60 +1701,60 @@
       }
     },
     "node_modules/@miniflare/d1": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.9.0.tgz",
-      "integrity": "sha512-swK9nzxw1SvVh/4cH3bRR1SBuHQU/YsB8WvuHojxufmgviAD1xhms3XO3rkpAzfKoGM5Oy6DovMe0xUXV/GS0w==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.14.0.tgz",
+      "integrity": "sha512-9YoeLAkZuWGAu9BMsoctHoMue0xHzJYZigAJWGvWrqSFT1gBaT+RlUefQCHXggi8P7sOJ1+BKlsWAhkB5wfMWQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.9.0.tgz",
-      "integrity": "sha512-7uTvfEUXS7xqwrsWOwWrFUuKc4EiMpVkAWPeYGLB/0TJaJ6N+sZMpYYymdW79TQwPIDfgtpfkIy93MRydqpnrw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.14.0.tgz",
+      "integrity": "sha512-P8eh1P62BPGpj+MCb1i1lj7Tlt/G3BMmnxHp9duyb0Wro/ILVGPQskZl+iq7DHq1w3C+n0+6/E1B44ff+qn0Mw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/storage-memory": "2.9.0",
-        "undici": "5.9.1"
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/storage-memory": "2.14.0",
+        "undici": "5.20.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.9.0.tgz",
-      "integrity": "sha512-K5OB70PtkMo7M+tU46s/cX/j/qtjD9AlJ0hecYswrxVsfrT/YWyrCQJevmShFfJ92h7jPNigbeC3Od3JiVb6QA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.14.0.tgz",
+      "integrity": "sha512-7CJZk3xZkxK8tGNofnhgWcChZ8YLx6MhAdN2nn6ONSXrK/TevzEKdL8bnVv1OJ6J8Y23OxvfinOhufr33tMS8g==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.9.0.tgz",
-      "integrity": "sha512-IVJMkFfMpecq9WiCTvATEKhMuKPK9fMs2E6zmgexaefr3u1VlNtj2QxBxoPUXkT9xMJQlT5sSKstlRR1XKDz9Q==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.14.0.tgz",
+      "integrity": "sha512-APaBlvGRAW+W18ph5ruPXX26/iKdByPz1tZH1OjPAKBDAiKFZSGek4QzUmQALBWLx5VMTMrt7QIe7KE4nM4sdw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/web-sockets": "2.9.0",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/web-sockets": "2.14.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.9.1",
+        "undici": "5.20.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -1763,62 +1763,63 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.9.0.tgz",
-      "integrity": "sha512-EqG51okY5rDtgjYs2Ny6j6IUVdTlJzDjwBKBIuW+wOV9NsAAzEchKVdYAXc8CyxvkggpYX481HydTD2OzK3INQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.14.0.tgz",
+      "integrity": "sha512-FHAnVjmhV/VHxgjNf2whraz+k7kfMKlfM+5gO8WT6HrOsWxSdx8OueWVScnOuuDkSeUg5Ctrf5SuztTV8Uy1cg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/shared": "2.14.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/queues": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.9.0.tgz",
-      "integrity": "sha512-cAHWIlLF57rxQaJl19AzXw1k0SOM/uLTlx8r2PylHajZ/RRSs7CkCox3oKA6E5zKyfyxk2M64bmsAFZ9RCA0gw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.14.0.tgz",
+      "integrity": "sha512-flS4MqlgBKyv6QBqKD0IofjmMDW9wP1prUNQy2wWPih9lA6bFKmml3VdFeDsPnWtE2J67K0vCTf5kj1Q0qdW1w==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/shared": "2.14.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/r2": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.9.0.tgz",
-      "integrity": "sha512-aMFWxxciAE3YsVok2OLy3A7hP5+2j/NaK7txmadgoe1CA8HYZyNuvv7v6bn8HKM5gWnJdT8sk4yEbMbBQ7Jv/A==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.14.0.tgz",
+      "integrity": "sha512-+WJJP4J0QzY69HPrG6g5OyW23lJ02WHpHZirCxwPSz8CajooqZCJVx+qvUcNmU8MyKASbUZMWnH79LysuBh+jA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.9.0",
-        "undici": "5.9.1"
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "undici": "5.20.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.9.0.tgz",
-      "integrity": "sha512-vewP+Fy7Czb261GmB9x/YtQkoDs/QP9B5LbP0YfJ35bI2C2j940eJLm8JP72IHV7ILtWNOqMc3Ure8uAbpf9NQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.14.0.tgz",
+      "integrity": "sha512-01CmNzv74u0RZgT/vjV/ggDzECXTG88ZJAKhXyhAx0s2DOLIXzsGHn6pUJIsfPCrtj8nfqtTCp1Vf0UMVWSpmw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/shared": "2.14.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.9.0.tgz",
-      "integrity": "sha512-eodSCGkJYi4Z+Imbx/bNScDfDSt5HOypVSYjbFHj+hA2aNOdkGw6a1b6mzwx49jJD3GadIkonZAKD0S114yWMA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.14.0.tgz",
+      "integrity": "sha512-/D28OeY/HxcOyY0rkPc2qU/wzxCcUv3/F7NRpgDix37sMkYjAAS51ehVIAkPwAdFEMdantcyVuHNQ2kO1xbT+Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -1826,14 +1827,14 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.9.0.tgz",
-      "integrity": "sha512-5Ew/Ph0cHDQqKvOlmN70kz+qZW0hdgE9fQBStKLY3vDYhnBEhopbCUChSS+FCcL7WtxVJJVE7iB6J09NQTnQ/A==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.14.0.tgz",
+      "integrity": "sha512-O0jAEdMkp8BzrdFCfMWZu76h4Cq+tt3/oDtcTFgzum3fRW5vUhIi/5f6bfndu6rkGbSlzxwor8CJWpzityXGug==",
       "dev": true,
       "dependencies": {
         "@types/better-sqlite3": "^7.6.0",
         "kleur": "^4.1.4",
-        "npx-import": "^1.1.3",
+        "npx-import": "^1.1.4",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -1841,65 +1842,65 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.9.0.tgz",
-      "integrity": "sha512-+tWf7znxSQqXWGzPup8Xqkl8EmLmx+HaLC+UBtWPNnaJZrsjbbVxKwHpmGIdm+wZasEGfQk/82R21gUs9wdZnw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.14.0.tgz",
+      "integrity": "sha512-qI8MFZpD1NV+g+HQ/qheDVwscKzwG58J+kAVTU/1fgub2lMLsxhE3Mmbi5AIpyIiJ7Q5Sezqga234CEkHkS7dA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/kv": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/storage-file": "2.9.0"
+        "@miniflare/kv": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/storage-file": "2.14.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.9.0.tgz",
-      "integrity": "sha512-HZHtHfJaLoDzQFddoIMcDGgAJ3/Nee98gwUYusQam7rj9pbEXnWmk54dzjzsDlkQpB/3MBFQNbtN5Bj1NIt0pg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.14.0.tgz",
+      "integrity": "sha512-Ps0wHhTO+ie33a58efI0p/ppFXSjlbYmykQXfYtMeVLD60CKl+4Lxor0+gD6uYDFbhMWL5/GMDvyr4AM87FA+Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/storage-memory": "2.9.0"
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/storage-memory": "2.14.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.9.0.tgz",
-      "integrity": "sha512-p2yrr0omQhv6teDbdzhdBKzoQAFmUBMLEx+PtrO7CJHX15ICD08/pFAFAp96IcljNwZZDchU20Z3AcbldMj6Tw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.14.0.tgz",
+      "integrity": "sha512-5aFjEiTSNrHJ+iAiGMCA/TVPnNMrnokG5r0vKrwj4knbf8pisgfP04x18zCgOlG7kaIWNmqdO/vtVT5BIioiSQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/shared": "2.14.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.9.0.tgz",
-      "integrity": "sha512-Yqz8Q1He/2chebXvmCft8sMamuUiDQ4FIn0bwiF0+GBP2vvGCmy6SejXZY4ZD4REluPqQSis3CLKcIOWlHnIsw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.14.0.tgz",
+      "integrity": "sha512-O8Abg2eHpGmcZb8WyUaA6Av1Mqt5bSrorzz4CrWwsvJHBdekZPIX0GihC9vn327d/1pKRs81YTiSAfBoSZpVIw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/shared": "2.14.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.9.0.tgz",
-      "integrity": "sha512-Nob9e84m78qeQCka6OQf/JdNOmMkKCkX+i3rg+TYKSSITiMVuyzWp3vz3Ma184lAZiLg44lxBF4ZzENEdi99Kg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.14.0.tgz",
+      "integrity": "sha512-lB1CB4rBq0mbCuh55WgIEH4L3c4/i4MNDBfrQL+6r+wGcr/BJUqF8BHpsfAt5yHWUJVtK5mlMeesS/xpg4Ao1w==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "undici": "5.9.1",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "undici": "5.20.0",
         "ws": "^8.2.2"
       },
       "engines": {
@@ -2249,9 +2250,9 @@
       }
     },
     "node_modules/@types/better-sqlite3": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
-      "integrity": "sha512-YS64N9SNDT/NAvou3QNdzAu3E2om/W/0dhORimtPGLef+zSK5l1vDzfsWb4xgXOgfhtOI5ZDTRxnvRPb22AIVQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.4.tgz",
+      "integrity": "sha512-dzrRZCYPXIXfSR1/surNbJ/grU3scTaygS0OMzjlGf71i9sc2fGyHPXXiXmEvNIoE0cGwsanEFMVJxPXmco9Eg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -3120,9 +3121,9 @@
       "dev": true
     },
     "node_modules/cardex": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.0.tgz",
-      "integrity": "sha512-YoCw1bSYSWoEGMTiqAkggVSBbDt+EiEd89qNKGzmIdoTd9vmksG6hjFo7dvyJvReb6QQrBvb7BrqHxqeX92C2g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.1.tgz",
+      "integrity": "sha512-01wTySlsJTWMSFf0UmqwjXSh65v6ZC5P1oDqmqnTR5BF3bLHOpGHSovSTK6R3hxRCdkfJOCCmw8m0Rq5f9NuUg==",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",
@@ -7329,32 +7330,32 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.9.0.tgz",
-      "integrity": "sha512-HBGQ5Jj6sMU1B1hX6G3ML46ThtUvu1nvxgXjDDmhp2RhWKYj0XvcohW/nPPL/MTP1gpvfT880De9EHmobVsDsw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.14.0.tgz",
+      "integrity": "sha512-xBOUccq1dm5riOfaqoMWCC1uCqT71EW0x4akQQuGYgm+Q44N1ETEmzXSbFVroJgOHe8Hwpqxo2D7OOFwqFevew==",
       "dev": true,
       "dependencies": {
-        "@miniflare/cache": "2.9.0",
-        "@miniflare/cli-parser": "2.9.0",
-        "@miniflare/core": "2.9.0",
-        "@miniflare/d1": "2.9.0",
-        "@miniflare/durable-objects": "2.9.0",
-        "@miniflare/html-rewriter": "2.9.0",
-        "@miniflare/http-server": "2.9.0",
-        "@miniflare/kv": "2.9.0",
-        "@miniflare/queues": "2.9.0",
-        "@miniflare/r2": "2.9.0",
-        "@miniflare/runner-vm": "2.9.0",
-        "@miniflare/scheduler": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/sites": "2.9.0",
-        "@miniflare/storage-file": "2.9.0",
-        "@miniflare/storage-memory": "2.9.0",
-        "@miniflare/web-sockets": "2.9.0",
+        "@miniflare/cache": "2.14.0",
+        "@miniflare/cli-parser": "2.14.0",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/d1": "2.14.0",
+        "@miniflare/durable-objects": "2.14.0",
+        "@miniflare/html-rewriter": "2.14.0",
+        "@miniflare/http-server": "2.14.0",
+        "@miniflare/kv": "2.14.0",
+        "@miniflare/queues": "2.14.0",
+        "@miniflare/r2": "2.14.0",
+        "@miniflare/runner-vm": "2.14.0",
+        "@miniflare/scheduler": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/sites": "2.14.0",
+        "@miniflare/storage-file": "2.14.0",
+        "@miniflare/storage-memory": "2.14.0",
+        "@miniflare/web-sockets": "2.14.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -7363,7 +7364,7 @@
         "node": ">=16.13"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.9.0",
+        "@miniflare/storage-redis": "2.14.0",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -8831,9 +8832,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
       "dev": true
     },
     "node_modules/set-delayed-interval": {
@@ -9561,10 +9562,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.9.1.tgz",
-      "integrity": "sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
       "engines": {
         "node": ">=12.18"
       }
@@ -11136,203 +11140,204 @@
       }
     },
     "@miniflare/cache": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.9.0.tgz",
-      "integrity": "sha512-lriPxUEva9TJ01vU9P7pI60s3SsFnb4apWkNwZ+D7CRqyXPipSbapY8BWI2FUIwkEG7xap6UhzeTS76NettCXQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.14.0.tgz",
+      "integrity": "sha512-0mz0OCzTegiX75uMURLJpDo3DaOCSx9M0gv7NMFWDbK/XrvjoENiBZiKu98UBM5fts0qtK19a+MfB4aT0uBCFg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.9.0.tgz",
-      "integrity": "sha512-gu8Z7NWNcYw6514/yOvajaj3GmebRucx+EEt3p1vKirO+gvFgKAt/puyUN3p7u8ZZmLuLF/B+wVnH3lj8BWKlg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.14.0.tgz",
+      "integrity": "sha512-6Wb0jTMqwI7GRGAhz9WOF8AONUsXXPmwu+Qhg+tnRWtQpJ3DYd5dku1N04L9L1R7np/mD8RrycLyCdg3hLZ3aA==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.9.0",
+        "@miniflare/shared": "2.14.0",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-QqSwF6oHvgrFvN5lnrLc6EEagFlZWW+UMU8QdrE8305cNGHrIOxKCA2nte4PVFZUVw/Ts13a0tVhUk3a2fAyxQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.14.0.tgz",
+      "integrity": "sha512-BjmV/ZDwsKvXnJntYHt3AQgzVKp/5ZzWPpYWoOnUSNxq6nnRCQyvFvjvBZKnhubcmJCLSqegvz0yHejMA90CTA==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/watcher": "2.9.0",
+        "@miniflare/queues": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/watcher": "2.14.0",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.9.1",
+        "undici": "5.20.0",
         "urlpattern-polyfill": "^4.0.3"
       }
     },
     "@miniflare/d1": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.9.0.tgz",
-      "integrity": "sha512-swK9nzxw1SvVh/4cH3bRR1SBuHQU/YsB8WvuHojxufmgviAD1xhms3XO3rkpAzfKoGM5Oy6DovMe0xUXV/GS0w==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.14.0.tgz",
+      "integrity": "sha512-9YoeLAkZuWGAu9BMsoctHoMue0xHzJYZigAJWGvWrqSFT1gBaT+RlUefQCHXggi8P7sOJ1+BKlsWAhkB5wfMWQ==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0"
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.9.0.tgz",
-      "integrity": "sha512-7uTvfEUXS7xqwrsWOwWrFUuKc4EiMpVkAWPeYGLB/0TJaJ6N+sZMpYYymdW79TQwPIDfgtpfkIy93MRydqpnrw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.14.0.tgz",
+      "integrity": "sha512-P8eh1P62BPGpj+MCb1i1lj7Tlt/G3BMmnxHp9duyb0Wro/ILVGPQskZl+iq7DHq1w3C+n0+6/E1B44ff+qn0Mw==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/storage-memory": "2.9.0",
-        "undici": "5.9.1"
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/storage-memory": "2.14.0",
+        "undici": "5.20.0"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.9.0.tgz",
-      "integrity": "sha512-K5OB70PtkMo7M+tU46s/cX/j/qtjD9AlJ0hecYswrxVsfrT/YWyrCQJevmShFfJ92h7jPNigbeC3Od3JiVb6QA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.14.0.tgz",
+      "integrity": "sha512-7CJZk3xZkxK8tGNofnhgWcChZ8YLx6MhAdN2nn6ONSXrK/TevzEKdL8bnVv1OJ6J8Y23OxvfinOhufr33tMS8g==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.9.0.tgz",
-      "integrity": "sha512-IVJMkFfMpecq9WiCTvATEKhMuKPK9fMs2E6zmgexaefr3u1VlNtj2QxBxoPUXkT9xMJQlT5sSKstlRR1XKDz9Q==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.14.0.tgz",
+      "integrity": "sha512-APaBlvGRAW+W18ph5ruPXX26/iKdByPz1tZH1OjPAKBDAiKFZSGek4QzUmQALBWLx5VMTMrt7QIe7KE4nM4sdw==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/web-sockets": "2.9.0",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/web-sockets": "2.14.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.9.1",
+        "undici": "5.20.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
     },
     "@miniflare/kv": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.9.0.tgz",
-      "integrity": "sha512-EqG51okY5rDtgjYs2Ny6j6IUVdTlJzDjwBKBIuW+wOV9NsAAzEchKVdYAXc8CyxvkggpYX481HydTD2OzK3INQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.14.0.tgz",
+      "integrity": "sha512-FHAnVjmhV/VHxgjNf2whraz+k7kfMKlfM+5gO8WT6HrOsWxSdx8OueWVScnOuuDkSeUg5Ctrf5SuztTV8Uy1cg==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/shared": "2.14.0"
       }
     },
     "@miniflare/queues": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.9.0.tgz",
-      "integrity": "sha512-cAHWIlLF57rxQaJl19AzXw1k0SOM/uLTlx8r2PylHajZ/RRSs7CkCox3oKA6E5zKyfyxk2M64bmsAFZ9RCA0gw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.14.0.tgz",
+      "integrity": "sha512-flS4MqlgBKyv6QBqKD0IofjmMDW9wP1prUNQy2wWPih9lA6bFKmml3VdFeDsPnWtE2J67K0vCTf5kj1Q0qdW1w==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/shared": "2.14.0"
       }
     },
     "@miniflare/r2": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.9.0.tgz",
-      "integrity": "sha512-aMFWxxciAE3YsVok2OLy3A7hP5+2j/NaK7txmadgoe1CA8HYZyNuvv7v6bn8HKM5gWnJdT8sk4yEbMbBQ7Jv/A==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.14.0.tgz",
+      "integrity": "sha512-+WJJP4J0QzY69HPrG6g5OyW23lJ02WHpHZirCxwPSz8CajooqZCJVx+qvUcNmU8MyKASbUZMWnH79LysuBh+jA==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.9.0",
-        "undici": "5.9.1"
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "undici": "5.20.0"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.9.0.tgz",
-      "integrity": "sha512-vewP+Fy7Czb261GmB9x/YtQkoDs/QP9B5LbP0YfJ35bI2C2j940eJLm8JP72IHV7ILtWNOqMc3Ure8uAbpf9NQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.14.0.tgz",
+      "integrity": "sha512-01CmNzv74u0RZgT/vjV/ggDzECXTG88ZJAKhXyhAx0s2DOLIXzsGHn6pUJIsfPCrtj8nfqtTCp1Vf0UMVWSpmw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/shared": "2.14.0"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.9.0.tgz",
-      "integrity": "sha512-eodSCGkJYi4Z+Imbx/bNScDfDSt5HOypVSYjbFHj+hA2aNOdkGw6a1b6mzwx49jJD3GadIkonZAKD0S114yWMA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.14.0.tgz",
+      "integrity": "sha512-/D28OeY/HxcOyY0rkPc2qU/wzxCcUv3/F7NRpgDix37sMkYjAAS51ehVIAkPwAdFEMdantcyVuHNQ2kO1xbT+Q==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.9.0.tgz",
-      "integrity": "sha512-5Ew/Ph0cHDQqKvOlmN70kz+qZW0hdgE9fQBStKLY3vDYhnBEhopbCUChSS+FCcL7WtxVJJVE7iB6J09NQTnQ/A==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.14.0.tgz",
+      "integrity": "sha512-O0jAEdMkp8BzrdFCfMWZu76h4Cq+tt3/oDtcTFgzum3fRW5vUhIi/5f6bfndu6rkGbSlzxwor8CJWpzityXGug==",
       "dev": true,
       "requires": {
         "@types/better-sqlite3": "^7.6.0",
         "kleur": "^4.1.4",
-        "npx-import": "^1.1.3",
+        "npx-import": "^1.1.4",
         "picomatch": "^2.3.1"
       }
     },
     "@miniflare/sites": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.9.0.tgz",
-      "integrity": "sha512-+tWf7znxSQqXWGzPup8Xqkl8EmLmx+HaLC+UBtWPNnaJZrsjbbVxKwHpmGIdm+wZasEGfQk/82R21gUs9wdZnw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.14.0.tgz",
+      "integrity": "sha512-qI8MFZpD1NV+g+HQ/qheDVwscKzwG58J+kAVTU/1fgub2lMLsxhE3Mmbi5AIpyIiJ7Q5Sezqga234CEkHkS7dA==",
       "dev": true,
       "requires": {
-        "@miniflare/kv": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/storage-file": "2.9.0"
+        "@miniflare/kv": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/storage-file": "2.14.0"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.9.0.tgz",
-      "integrity": "sha512-HZHtHfJaLoDzQFddoIMcDGgAJ3/Nee98gwUYusQam7rj9pbEXnWmk54dzjzsDlkQpB/3MBFQNbtN5Bj1NIt0pg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.14.0.tgz",
+      "integrity": "sha512-Ps0wHhTO+ie33a58efI0p/ppFXSjlbYmykQXfYtMeVLD60CKl+4Lxor0+gD6uYDFbhMWL5/GMDvyr4AM87FA+Q==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/storage-memory": "2.9.0"
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/storage-memory": "2.14.0"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.9.0.tgz",
-      "integrity": "sha512-p2yrr0omQhv6teDbdzhdBKzoQAFmUBMLEx+PtrO7CJHX15ICD08/pFAFAp96IcljNwZZDchU20Z3AcbldMj6Tw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.14.0.tgz",
+      "integrity": "sha512-5aFjEiTSNrHJ+iAiGMCA/TVPnNMrnokG5r0vKrwj4knbf8pisgfP04x18zCgOlG7kaIWNmqdO/vtVT5BIioiSQ==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/shared": "2.14.0"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.9.0.tgz",
-      "integrity": "sha512-Yqz8Q1He/2chebXvmCft8sMamuUiDQ4FIn0bwiF0+GBP2vvGCmy6SejXZY4ZD4REluPqQSis3CLKcIOWlHnIsw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.14.0.tgz",
+      "integrity": "sha512-O8Abg2eHpGmcZb8WyUaA6Av1Mqt5bSrorzz4CrWwsvJHBdekZPIX0GihC9vn327d/1pKRs81YTiSAfBoSZpVIw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.9.0"
+        "@miniflare/shared": "2.14.0"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.9.0.tgz",
-      "integrity": "sha512-Nob9e84m78qeQCka6OQf/JdNOmMkKCkX+i3rg+TYKSSITiMVuyzWp3vz3Ma184lAZiLg44lxBF4ZzENEdi99Kg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.14.0.tgz",
+      "integrity": "sha512-lB1CB4rBq0mbCuh55WgIEH4L3c4/i4MNDBfrQL+6r+wGcr/BJUqF8BHpsfAt5yHWUJVtK5mlMeesS/xpg4Ao1w==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "undici": "5.9.1",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "undici": "5.20.0",
         "ws": "^8.2.2"
       }
     },
@@ -11643,9 +11648,9 @@
       }
     },
     "@types/better-sqlite3": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
-      "integrity": "sha512-YS64N9SNDT/NAvou3QNdzAu3E2om/W/0dhORimtPGLef+zSK5l1vDzfsWb4xgXOgfhtOI5ZDTRxnvRPb22AIVQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.4.tgz",
+      "integrity": "sha512-dzrRZCYPXIXfSR1/surNbJ/grU3scTaygS0OMzjlGf71i9sc2fGyHPXXiXmEvNIoE0cGwsanEFMVJxPXmco9Eg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -12338,9 +12343,9 @@
       }
     },
     "cardex": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.0.tgz",
-      "integrity": "sha512-YoCw1bSYSWoEGMTiqAkggVSBbDt+EiEd89qNKGzmIdoTd9vmksG6hjFo7dvyJvReb6QQrBvb7BrqHxqeX92C2g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cardex/-/cardex-2.2.1.tgz",
+      "integrity": "sha512-01wTySlsJTWMSFf0UmqwjXSh65v6ZC5P1oDqmqnTR5BF3bLHOpGHSovSTK6R3hxRCdkfJOCCmw8m0Rq5f9NuUg==",
       "requires": {
         "@ipld/car": "^5.1.0",
         "multiformats": "^11.0.2",
@@ -15495,32 +15500,32 @@
       "dev": true
     },
     "miniflare": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.9.0.tgz",
-      "integrity": "sha512-HBGQ5Jj6sMU1B1hX6G3ML46ThtUvu1nvxgXjDDmhp2RhWKYj0XvcohW/nPPL/MTP1gpvfT880De9EHmobVsDsw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.14.0.tgz",
+      "integrity": "sha512-xBOUccq1dm5riOfaqoMWCC1uCqT71EW0x4akQQuGYgm+Q44N1ETEmzXSbFVroJgOHe8Hwpqxo2D7OOFwqFevew==",
       "dev": true,
       "requires": {
-        "@miniflare/cache": "2.9.0",
-        "@miniflare/cli-parser": "2.9.0",
-        "@miniflare/core": "2.9.0",
-        "@miniflare/d1": "2.9.0",
-        "@miniflare/durable-objects": "2.9.0",
-        "@miniflare/html-rewriter": "2.9.0",
-        "@miniflare/http-server": "2.9.0",
-        "@miniflare/kv": "2.9.0",
-        "@miniflare/queues": "2.9.0",
-        "@miniflare/r2": "2.9.0",
-        "@miniflare/runner-vm": "2.9.0",
-        "@miniflare/scheduler": "2.9.0",
-        "@miniflare/shared": "2.9.0",
-        "@miniflare/sites": "2.9.0",
-        "@miniflare/storage-file": "2.9.0",
-        "@miniflare/storage-memory": "2.9.0",
-        "@miniflare/web-sockets": "2.9.0",
+        "@miniflare/cache": "2.14.0",
+        "@miniflare/cli-parser": "2.14.0",
+        "@miniflare/core": "2.14.0",
+        "@miniflare/d1": "2.14.0",
+        "@miniflare/durable-objects": "2.14.0",
+        "@miniflare/html-rewriter": "2.14.0",
+        "@miniflare/http-server": "2.14.0",
+        "@miniflare/kv": "2.14.0",
+        "@miniflare/queues": "2.14.0",
+        "@miniflare/r2": "2.14.0",
+        "@miniflare/runner-vm": "2.14.0",
+        "@miniflare/scheduler": "2.14.0",
+        "@miniflare/shared": "2.14.0",
+        "@miniflare/sites": "2.14.0",
+        "@miniflare/storage-file": "2.14.0",
+        "@miniflare/storage-memory": "2.14.0",
+        "@miniflare/web-sockets": "2.14.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       }
     },
     "minimatch": {
@@ -16542,9 +16547,9 @@
       }
     },
     "set-cookie-parser": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
       "dev": true
     },
     "set-delayed-interval": {
@@ -17079,10 +17084,13 @@
       }
     },
     "undici": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.9.1.tgz",
-      "integrity": "sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==",
-      "dev": true
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
     "@web3-storage/gateway-lib": "^3.2.2",
-    "cardex": "^2.2.1",
+    "cardex": "^2.2.2",
     "chardet": "^1.5.0",
     "dagula": "^7.0.0",
     "magic-bytes.js": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
     "@web3-storage/gateway-lib": "^3.2.2",
-    "cardex": "^2.2.0",
+    "cardex": "^2.2.1",
     "chardet": "^1.5.0",
     "dagula": "^7.0.0",
     "magic-bytes.js": "^1.0.12",
@@ -43,7 +43,7 @@
     "esbuild": "^0.17.11",
     "files-from-path": "^0.2.6",
     "ipfs-car": "^0.9.2",
-    "miniflare": "^2.9.0",
+    "miniflare": "^2.14.0",
     "standard": "^17.0.0",
     "uint8arrays": "^4.0.3"
   },

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -10,6 +10,7 @@ export interface Environment {
   CARPARK: R2Bucket
   DUDEWHERE: R2Bucket
   SATNAV: R2Bucket
+  BLOCKLY: R2Bucket
   MAX_SHARDS: string
 }
 

--- a/src/lib/blockstore.js
+++ b/src/lib/blockstore.js
@@ -1,7 +1,6 @@
 import { readBlockHead, asyncIterableReader } from '@ipld/car/decoder'
 import { base58btc } from 'multiformats/bases/base58'
 import defer from 'p-defer'
-import { MultiCarIndex, StreamingCarIndex } from './car-index.js'
 import { OrderedCarBlockBatcher } from './block-batch.js'
 
 /**
@@ -23,14 +22,11 @@ const MAX_ENCODED_BLOCK_LENGTH = (1024 * 1024 * 2) + 39 + 61
 export class R2Blockstore {
   /**
    * @param {R2Bucket} dataBucket
-   * @param {import('../bindings').IndexSource[]} indexSources
+   * @param {import('./car-index').CarIndex} index
    */
-  constructor (dataBucket, indexSources) {
+  constructor (dataBucket, index) {
     this._dataBucket = dataBucket
-    this._idx = new MultiCarIndex()
-    for (const src of indexSources) {
-      this._idx.addIndex(new StreamingCarIndex(src))
-    }
+    this._idx = index
   }
 
   /** @param {UnknownLink} cid */

--- a/src/lib/car-index.js
+++ b/src/lib/car-index.js
@@ -91,7 +91,7 @@ export class StreamingCarIndex {
         const entry = /** @type {IndexEntry} */(value)
         entry.origin = entry.origin ?? this.#source.origin
 
-        const key = mhToKey(entry.multihash)
+        const key = mhToString(entry.multihash)
 
         // set this value in the index so any future requests for this key get
         // the value immediately, without joining the promised index, even if we
@@ -135,7 +135,7 @@ export class StreamingCarIndex {
     if (this.#buildError) {
       throw new Error('failed to build index', { cause: this.#buildError })
     }
-    const key = mhToKey(cid.multihash)
+    const key = mhToString(cid.multihash)
     const entry = this.#idx.get(key)
     if (entry != null) return entry
     if (this.#building) {
@@ -149,10 +149,11 @@ export class StreamingCarIndex {
 }
 
 /**
+ * Multibase encode a multihash with base58btc.
  * @param {import('multiformats').MultihashDigest} mh
  * @returns {import('multiformats').ToString<import('multiformats').MultihashDigest, 'z'>}
  */
-const mhToKey = mh => base58btc.encode(mh.bytes)
+const mhToString = mh => base58btc.encode(mh.bytes)
 
 export class BlocklyIndex {
   /** R2 bucket where indexes live. */
@@ -174,7 +175,7 @@ export class BlocklyIndex {
 
   /** @param {UnknownLink} cid */
   async get (cid) {
-    const key = mhToKey(cid.multihash)
+    const key = mhToString(cid.multihash)
     let indexItem = this.#cache.get(key)
     if (indexItem) {
       if (cid.code !== raw.code) {
@@ -192,7 +193,7 @@ export class BlocklyIndex {
    * @param {import('multiformats').UnknownLink} cid
    */
   async #readIndex (cid) {
-    const key = mhToKey(cid.multihash)
+    const key = mhToString(cid.multihash)
     if (this.#indexes.has(key)) return
 
     const res = await this.#bucket.get(`${key}/${key}.idx`)
@@ -205,7 +206,7 @@ export class BlocklyIndex {
 
       if (!('multihash' in value)) throw new Error('not MultihashIndexSorted')
       const entry = /** @type {IndexEntry} */(value)
-      this.#cache.set(mhToKey(entry.multihash), entry)
+      this.#cache.set(mhToString(entry.multihash), entry)
     }
     this.#indexes.add(key)
   }

--- a/src/lib/car-index.js
+++ b/src/lib/car-index.js
@@ -172,18 +172,16 @@ export class BlocklyIndex {
 
   /** @param {UnknownLink} cid */
   async get (cid) {
-    // console.log(`index get: ${cid}`)
     const key = cidToKey(cid)
     let indexItem = this.#cache.get(key)
     if (indexItem) {
-      // console.log(`index cache HIT: ${indexItem.origin}: ${cid} @ ${indexItem.offset}`)
       if (cid.code !== raw.code) {
         await this.#readIndex(cid)
       }
     } else {
       await this.#readIndex(cid)
       indexItem = this.#cache.get(key)
-      if (!indexItem) return // weird huh!?
+      if (!indexItem) return
     }
     return { cid, ...indexItem }
   }
@@ -195,7 +193,6 @@ export class BlocklyIndex {
     const key = cidToKey(cid)
     if (this.#indexes.has(key)) return
 
-    // console.log(`reading block index: ${key}`)
     const res = await this.#bucket.get(`${key}/${key}.idx`)
     if (!res) return
 
@@ -207,7 +204,6 @@ export class BlocklyIndex {
       if (!('multihash' in value)) throw new Error('not MultihashIndexSorted')
       const entry = /** @type {IndexEntry} */(value)
       const rawCid = Link.create(raw.code, entry.multihash)
-      // console.log(`${cid}: ${value.origin}: ${rawCid} @ ${value.offset}`)
       this.#cache.set(cidToKey(rawCid), entry)
     }
     this.#indexes.add(key)

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -103,7 +103,7 @@ export function withIndexSources (handler) {
  */
 export function withDagula (handler) {
   return async (request, env, ctx) => {
-    const { indexSources, searchParams } = ctx
+    const { indexSources, searchParams, dataCid } = ctx
     if (!indexSources) throw new Error('missing index sources in context')
     if (!searchParams) throw new Error('missing URL search params in context')
 
@@ -129,7 +129,10 @@ export function withDagula (handler) {
         blockstore = new BatchingR2Blockstore(env.CARPARK, index)
       }
     } else {
-      blockstore = new BatchingR2Blockstore(env.CARPARK, new BlocklyIndex(env.BLOCKLY))
+      const index = new BlocklyIndex(env.BLOCKLY)
+      const found = await index.get(dataCid)
+      if (!found) throw new HttpError('missing index', { status: 404 })
+      blockstore = new BatchingR2Blockstore(env.CARPARK, index)
     }
 
     const dagula = new Dagula(blockstore)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -181,7 +181,7 @@ export class Builder {
       while (true) {
         const { done, value } = await reader.read()
         if (done) break
-        const blockMh = mhToKey(value.multihash)
+        const blockMh = mhToString(value.multihash)
         let offsets = blockIndex.get(blockMh)
         if (!offsets) {
           /** @type {Map<ShardCID, Offset>} */
@@ -200,7 +200,7 @@ export class Builder {
       const shardIndex = new Map([[parentShard, new Map([[blockMh, offset]])]])
       const block = await getBlock(this.#carpark, parentShard, offset)
       for (const [, cid] of block.links()) {
-        const linkMh = mhToKey(cid.multihash)
+        const linkMh = mhToString(cid.multihash)
         const offsets = blockIndex.get(linkMh)
         if (!offsets) throw new Error(`block not indexed: ${cid}`)
         const [shard, offset] = offsets.has(parentShard) ? [parentShard, offsets.get(parentShard) ?? 0] : getAnyMapEntry(offsets)
@@ -310,4 +310,4 @@ async function getBlock (bucket, shardCID, offset) {
  * @param {import('multiformats').MultihashDigest} mh
  * @returns {import('multiformats').ToString<import('multiformats').MultihashDigest, 'z'>}
  */
-const mhToKey = mh => base58btc.encode(mh.bytes)
+const mhToString = mh => base58btc.encode(mh.bytes)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -138,7 +138,7 @@ export class Builder {
     const satnav = this.#satnav
     const rollupGenerator = async function * () {
       yield encodeVarint(MultiIndexWriter.codec)
-      yield encodeUint32LE(carCids.length)
+      yield encodeVarint(carCids.length)
       for (const origin of carCids) {
         yield origin.multihash.bytes
         const carIdx = await satnav.get(`${origin}/${origin}.car.idx`)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,5 @@
 /* global TransformStream, ReadableStream */
 import { pack } from 'ipfs-car/pack'
-import { CID } from 'multiformats/cid'
 import * as Link from 'multiformats/link'
 import * as raw from 'multiformats/codecs/raw'
 import * as Block from 'multiformats/block'
@@ -215,10 +214,10 @@ export class Builder {
       const writer = MultiIndexWriter.createWriter({ writer: writable.getWriter() })
 
       for (const [shardCID, blocks] of shardIndex.entries()) {
-        writer.add(CID.parse(shardCID), async ({ writer }) => {
+        writer.add(Link.parse(shardCID), async ({ writer }) => {
           const index = MultihashIndexSortedWriter.createWriter({ writer })
           for (const [cid, offset] of blocks.entries()) {
-            index.add(CID.parse(cid), offset)
+            index.add(Link.parse(cid), offset)
           }
           await index.close()
         })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,7 +13,7 @@ describe('freeway', () => {
   let builder
 
   before(async () => {
-    const bucketNames = ['CARPARK', 'SATNAV', 'DUDEWHERE']
+    const bucketNames = ['CARPARK', 'SATNAV', 'DUDEWHERE', 'BLOCKLY']
 
     miniflare = new Miniflare({
       bindings: {},
@@ -31,90 +31,111 @@ describe('freeway', () => {
     })
 
     const buckets = await Promise.all(bucketNames.map(b => miniflare.getR2Bucket(b)))
-    builder = new Builder(buckets[0], buckets[1], buckets[2])
+    builder = new Builder(buckets[0], buckets[1], buckets[2], buckets[3])
   })
 
-  it('should get a file', async () => {
-    const input = randomBytes(256)
-    const { dataCid } = await builder.add(input, { wrapWithDirectory: false })
+  // it('should get a file', async () => {
+  //   const input = randomBytes(256)
+  //   const { dataCid } = await builder.add(input, { wrapWithDirectory: false })
 
-    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}`)
-    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+  //   const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}`)
+  //   if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
 
-    const output = new Uint8Array(await res.arrayBuffer())
-    assert(equals(input, output))
-  })
+  //   const output = new Uint8Array(await res.arrayBuffer())
+  //   assert(equals(input, output))
+  // })
 
-  it('should get a file in a directory', async () => {
-    const input = [
-      { path: 'data.txt', content: randomBytes(256) },
-      { path: 'image.png', content: randomBytes(512) }
-    ]
-    const { dataCid } = await builder.add(input)
+  // it('should get a file in a directory', async () => {
+  //   const input = [
+  //     { path: 'data.txt', content: randomBytes(256) },
+  //     { path: 'image.png', content: randomBytes(512) }
+  //   ]
+  //   const { dataCid } = await builder.add(input)
 
-    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
-    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+  //   const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+  //   if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
 
-    const output = new Uint8Array(await res.arrayBuffer())
-    assert(equals(input[0].content, output))
-  })
+  //   const output = new Uint8Array(await res.arrayBuffer())
+  //   assert(equals(input[0].content, output))
+  // })
 
-  it('should get a big file', async () => {
-    const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
-    const { dataCid } = await builder.add(input)
+  // it('should get a big file', async () => {
+  //   const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
+  //   const { dataCid } = await builder.add(input)
 
-    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
-    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+  //   const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+  //   if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
 
-    const output = new Uint8Array(await res.arrayBuffer())
-    assert(equals(input[0].content, output))
-  })
+  //   const output = new Uint8Array(await res.arrayBuffer())
+  //   assert(equals(input[0].content, output))
+  // })
 
-  it('should fail when divided into more than 120 CAR files', async () => {
-    const input = [{ path: 'sargo.tar.xz', content: randomBytes(1218523560) }]
-    const { dataCid } = await builder.add(input)
+  // it('should fail when divided into more than 120 CAR files', async () => {
+  //   const input = [{ path: 'sargo.tar.xz', content: randomBytes(1218523560) }]
+  //   const { dataCid } = await builder.add(input)
 
-    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+  //   const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
 
-    assert(!res.ok)
-    assert.equal(res.status, 501)
-  })
+  //   assert(!res.ok)
+  //   assert.equal(res.status, 501)
+  // })
 
-  it('should get a CAR via Accept headers', async () => {
-    const input = randomBytes(256)
-    const { dataCid } = await builder.add(input, { wrapWithDirectory: false })
+  // it('should get a CAR via Accept headers', async () => {
+  //   const input = randomBytes(256)
+  //   const { dataCid } = await builder.add(input, { wrapWithDirectory: false })
 
-    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}`, {
-      headers: { Accept: 'application/vnd.ipld.car;order=dfs;' }
-    })
-    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+  //   const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}`, {
+  //     headers: { Accept: 'application/vnd.ipld.car;order=dfs;' }
+  //   })
+  //   if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
 
-    const contentType = res.headers.get('Content-Type')
-    assert(contentType)
-    assert(contentType.includes('application/vnd.ipld.car'))
-    assert(contentType.includes('order=dfs'))
+  //   const contentType = res.headers.get('Content-Type')
+  //   assert(contentType)
+  //   assert(contentType.includes('application/vnd.ipld.car'))
+  //   assert(contentType.includes('order=dfs'))
 
-    const output = new Uint8Array(await res.arrayBuffer())
-    assert.doesNotReject(CarReader.fromBytes(output))
-  })
+  //   const output = new Uint8Array(await res.arrayBuffer())
+  //   assert.doesNotReject(CarReader.fromBytes(output))
+  // })
 
-  it('should use a rollup index', async () => {
+  // it('should use a rollup index', async () => {
+  //   const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
+  //   const { dataCid, carCids } = await builder.add(input)
+
+  //   // remove the the CAR CIDs from DUDEWHERE so that only the rollup index can
+  //   // be used to satisfy the request.
+  //   const bucket = await miniflare.getR2Bucket('DUDEWHERE')
+  //   for (const cid of carCids) {
+  //     await bucket.delete(`${dataCid}/${cid}`)
+  //   }
+
+  //   // should NOT be able to serve this CID now
+  //   const res0 = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+  //   assert.equal(res0.status, 404)
+
+  //   // generate the rollup index
+  //   await builder.rollup(dataCid, carCids)
+
+  //   const res1 = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+  //   if (!res1.ok) assert.fail(`unexpected response: ${await res1.text()}`)
+
+  //   const output = new Uint8Array(await res1.arrayBuffer())
+  //   assert(equals(input[0].content, output))
+  // })
+
+  it('should fallback to blockly', async () => {
     const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
     const { dataCid, carCids } = await builder.add(input)
 
-    // remove the the CAR CIDs from DUDEWHERE so that only the rollup index can
+    // generate blockly blocks
+    await builder.blocks(dataCid)
+
+    // remove the the CAR CIDs from DUDEWHERE so that only blockly can
     // be used to satisfy the request.
     const bucket = await miniflare.getR2Bucket('DUDEWHERE')
     for (const cid of carCids) {
       await bucket.delete(`${dataCid}/${cid}`)
     }
-
-    // should NOT be able to serve this CID now
-    const res0 = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
-    assert.equal(res0.status, 404)
-
-    // generate the rollup index
-    await builder.rollup(dataCid, carCids)
 
     const res1 = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
     if (!res1.ok) assert.fail(`unexpected response: ${await res1.text()}`)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -34,94 +34,94 @@ describe('freeway', () => {
     builder = new Builder(buckets[0], buckets[1], buckets[2], buckets[3])
   })
 
-  // it('should get a file', async () => {
-  //   const input = randomBytes(256)
-  //   const { dataCid } = await builder.add(input, { wrapWithDirectory: false })
+  it('should get a file', async () => {
+    const input = randomBytes(256)
+    const { dataCid } = await builder.add(input, { wrapWithDirectory: false })
 
-  //   const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}`)
-  //   if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}`)
+    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
 
-  //   const output = new Uint8Array(await res.arrayBuffer())
-  //   assert(equals(input, output))
-  // })
+    const output = new Uint8Array(await res.arrayBuffer())
+    assert(equals(input, output))
+  })
 
-  // it('should get a file in a directory', async () => {
-  //   const input = [
-  //     { path: 'data.txt', content: randomBytes(256) },
-  //     { path: 'image.png', content: randomBytes(512) }
-  //   ]
-  //   const { dataCid } = await builder.add(input)
+  it('should get a file in a directory', async () => {
+    const input = [
+      { path: 'data.txt', content: randomBytes(256) },
+      { path: 'image.png', content: randomBytes(512) }
+    ]
+    const { dataCid } = await builder.add(input)
 
-  //   const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
-  //   if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
 
-  //   const output = new Uint8Array(await res.arrayBuffer())
-  //   assert(equals(input[0].content, output))
-  // })
+    const output = new Uint8Array(await res.arrayBuffer())
+    assert(equals(input[0].content, output))
+  })
 
-  // it('should get a big file', async () => {
-  //   const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
-  //   const { dataCid } = await builder.add(input)
+  it('should get a big file', async () => {
+    const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
+    const { dataCid } = await builder.add(input)
 
-  //   const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
-  //   if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
 
-  //   const output = new Uint8Array(await res.arrayBuffer())
-  //   assert(equals(input[0].content, output))
-  // })
+    const output = new Uint8Array(await res.arrayBuffer())
+    assert(equals(input[0].content, output))
+  })
 
-  // it('should fail when divided into more than 120 CAR files', async () => {
-  //   const input = [{ path: 'sargo.tar.xz', content: randomBytes(1218523560) }]
-  //   const { dataCid } = await builder.add(input)
+  it('should fail when divided into more than 120 CAR files', async () => {
+    const input = [{ path: 'sargo.tar.xz', content: randomBytes(1218523560) }]
+    const { dataCid } = await builder.add(input)
 
-  //   const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
 
-  //   assert(!res.ok)
-  //   assert.equal(res.status, 501)
-  // })
+    assert(!res.ok)
+    assert.equal(res.status, 501)
+  })
 
-  // it('should get a CAR via Accept headers', async () => {
-  //   const input = randomBytes(256)
-  //   const { dataCid } = await builder.add(input, { wrapWithDirectory: false })
+  it('should get a CAR via Accept headers', async () => {
+    const input = randomBytes(256)
+    const { dataCid } = await builder.add(input, { wrapWithDirectory: false })
 
-  //   const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}`, {
-  //     headers: { Accept: 'application/vnd.ipld.car;order=dfs;' }
-  //   })
-  //   if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
+    const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}`, {
+      headers: { Accept: 'application/vnd.ipld.car;order=dfs;' }
+    })
+    if (!res.ok) assert.fail(`unexpected response: ${await res.text()}`)
 
-  //   const contentType = res.headers.get('Content-Type')
-  //   assert(contentType)
-  //   assert(contentType.includes('application/vnd.ipld.car'))
-  //   assert(contentType.includes('order=dfs'))
+    const contentType = res.headers.get('Content-Type')
+    assert(contentType)
+    assert(contentType.includes('application/vnd.ipld.car'))
+    assert(contentType.includes('order=dfs'))
 
-  //   const output = new Uint8Array(await res.arrayBuffer())
-  //   assert.doesNotReject(CarReader.fromBytes(output))
-  // })
+    const output = new Uint8Array(await res.arrayBuffer())
+    assert.doesNotReject(CarReader.fromBytes(output))
+  })
 
-  // it('should use a rollup index', async () => {
-  //   const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
-  //   const { dataCid, carCids } = await builder.add(input)
+  it('should use a rollup index', async () => {
+    const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]
+    const { dataCid, carCids } = await builder.add(input)
 
-  //   // remove the the CAR CIDs from DUDEWHERE so that only the rollup index can
-  //   // be used to satisfy the request.
-  //   const bucket = await miniflare.getR2Bucket('DUDEWHERE')
-  //   for (const cid of carCids) {
-  //     await bucket.delete(`${dataCid}/${cid}`)
-  //   }
+    // remove the the CAR CIDs from DUDEWHERE so that only the rollup index can
+    // be used to satisfy the request.
+    const bucket = await miniflare.getR2Bucket('DUDEWHERE')
+    for (const cid of carCids) {
+      await bucket.delete(`${dataCid}/${cid}`)
+    }
 
-  //   // should NOT be able to serve this CID now
-  //   const res0 = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
-  //   assert.equal(res0.status, 404)
+    // should NOT be able to serve this CID now
+    const res0 = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+    assert.equal(res0.status, 404)
 
-  //   // generate the rollup index
-  //   await builder.rollup(dataCid, carCids)
+    // generate the rollup index
+    await builder.rollup(dataCid, carCids)
 
-  //   const res1 = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
-  //   if (!res1.ok) assert.fail(`unexpected response: ${await res1.text()}`)
+    const res1 = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
+    if (!res1.ok) assert.fail(`unexpected response: ${await res1.text()}`)
 
-  //   const output = new Uint8Array(await res1.arrayBuffer())
-  //   assert(equals(input[0].content, output))
-  // })
+    const output = new Uint8Array(await res1.arrayBuffer())
+    assert(equals(input[0].content, output))
+  })
 
   it('should fallback to blockly', async () => {
     const input = [{ path: 'sargo.tar.xz', content: randomBytes(609261780) }]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,8 @@ compatibility_flags = [
 r2_buckets = [
   { binding = "CARPARK", bucket_name = "carpark-dev-0" },
   { binding = "DUDEWHERE", bucket_name = "dudewhere-dev-0" },
-  { binding = "SATNAV", bucket_name = "satnav-dev-0" }
+  { binding = "SATNAV", bucket_name = "satnav-dev-0" },
+  { binding = "BLOCKLY", bucket_name = "blockly-dev-0" }
 ]
 
 [build]
@@ -21,7 +22,8 @@ route = { pattern = "https://freeway.dag.haus/*", zone_id = "f2f8a5b1c557202c6e3
 r2_buckets = [
   { binding = "CARPARK", bucket_name = "carpark-prod-0" },
   { binding = "DUDEWHERE", bucket_name = "dudewhere-prod-0" },
-  { binding = "SATNAV", bucket_name = "satnav-prod-0" }
+  { binding = "SATNAV", bucket_name = "satnav-prod-0" },
+  { binding = "BLOCKLY", bucket_name = "blockly-prod-0" }
 ]
 
 [env.production.build]
@@ -37,7 +39,8 @@ route = { pattern = "https://freeway-staging.dag.haus/*", zone_id = "f2f8a5b1c55
 r2_buckets = [
   { binding = "CARPARK", bucket_name = "carpark-staging-0" },
   { binding = "DUDEWHERE", bucket_name = "dudewhere-staging-0" },
-  { binding = "SATNAV", bucket_name = "satnav-staging-0" }
+  { binding = "SATNAV", bucket_name = "satnav-staging-0" },
+  { binding = "BLOCKLY", bucket_name = "blockly-staging-0" }
 ]
 
 [env.staging.build]
@@ -52,7 +55,8 @@ workers_dev = true
 r2_buckets = [
   { binding = "CARPARK", bucket_name = "carpark-test-0" },
   { binding = "DUDEWHERE", bucket_name = "dudewhere-test-0" },
-  { binding = "SATNAV", bucket_name = "satnav-test-0" }
+  { binding = "SATNAV", bucket_name = "satnav-test-0" },
+  { binding = "BLOCKLY", bucket_name = "blockly-test-0" }
 ]
 
 [env.test.vars]
@@ -65,7 +69,8 @@ account_id = "4fe12d085474d33bdcfd8e9bed4d8f95"
 r2_buckets = [
   { binding = "CARPARK", bucket_name = "carpark-alanshaw-0", preview_bucket_name = "carpark-alanshaw-preview-0" },
   { binding = "DUDEWHERE", bucket_name = "dudewhere-alanshaw-0", preview_bucket_name = "dudewhere-alanshaw-preview-0" },
-  { binding = "SATNAV", bucket_name = "satnav-alanshaw-0", preview_bucket_name = "satnav-alanshaw-preview-0" }
+  { binding = "SATNAV", bucket_name = "satnav-alanshaw-0", preview_bucket_name = "satnav-alanshaw-preview-0" },
+  { binding = "BLOCKLY", bucket_name = "blockly-alanshaw-0", preview_bucket_name = "blockly-alanshaw-preview-0" }
 ]
 
 [env.alanshaw.vars]


### PR DESCRIPTION
This PR adds support for "block link indexes" as a fallback, if content cannot be served by DUDEWHERE and SATNAV.

It binds a new bucket `BLOCKLY` (BLOCK+LYnks) and adds a new index implementation that uses the files stored in it. 

Blockly is a collection of [multi-indexes](https://github.com/web3-storage/specs/blob/73c386b999cf30fb648987ff9dce0516c1d91137/CARv2%20MultiIndex.md) for individual blocks. Each index contains the CID of a CAR file the block may be found in and the block's byte offset. The index also contains the _same detail for any links_ the block has.