### PR TITLE
fix: blockly index key

### DIFF
--- a/src/lib/car-index.js
+++ b/src/lib/car-index.js
@@ -213,7 +213,7 @@ export class BlocklyIndex {
     const key = mhToString(cid.multihash)
     if (this.#indexes.has(key)) return
 
-    const res = await this.#bucket.get(`${key}/${key}.idx`)
+    const res = await this.#bucket.get(`${key}/.idx`)
     if (!res) return
 
     const reader = MultiIndexReader.createReader({ reader: res.body.getReader() })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -193,7 +193,7 @@ export class Builder {
     }
 
     for (const [blockMh, offsets] of blockIndex) {
-      const key = `${blockMh}/${blockMh}.idx`
+      const key = `${blockMh}/.idx`
 
       const [parentShard, offset] = getAnyMapEntry(offsets)
       /** @type {Map<ShardCID, Map<MultihashString, Offset>>} */


### PR DESCRIPTION
The index key changed to accommodate multiple indexes of block in different CAR shards.