### PR TITLE
feat: fallback to blockly when shard limit exceeded

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -48,7 +48,7 @@ export function withIndexSources (handler) {
     const maxShards = env.MAX_SHARDS ? parseInt(env.MAX_SHARDS) : 825
 
     /** @type {import('./bindings').IndexSource[]} */
-    const indexSources = ctx.searchParams
+    let indexSources = ctx.searchParams
       .getAll('origin')
       .flatMap(str => {
         return str.split(',')
@@ -84,7 +84,8 @@ export function withIndexSources (handler) {
         }))
 
         if (indexSources.length > maxShards) {
-          throw new HttpError('request exceeds maximum DAG shards', { status: 501 })
+          console.warn('exceeds maximum DAG shards') // fallback to blockly
+          indexSources = []
         }
 
         if (!results.truncated) break

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -77,7 +77,7 @@ describe('freeway', () => {
     const res = await miniflare.dispatchFetch(`http://localhost:8787/ipfs/${dataCid}/${input[0].path}`)
 
     assert(!res.ok)
-    assert.equal(res.status, 501)
+    assert.equal(res.status, 404)
   })
 
   it('should get a CAR via Accept headers', async () => {


### PR DESCRIPTION
When there's too many shards, fallback to blockly as it is likely to be able to satisfy the request (provided indexes exist).